### PR TITLE
add missing test deps, enable pytest integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
               '(with Python 3.5 or later recommended).')
         sys.exit(1)
         
-    requires = ['pytest', 'jinja2', 'simplegeneric']
+    requires = ['jinja2', 'simplegeneric']
 
     if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 4):
         requires.append('singledispatch')
@@ -159,7 +159,8 @@ if __name__ == '__main__':
         author_email = 'lgautier@gmail.com',
         requires = requires,
         install_requires = requires + ['cffi>=1.0.0'],
-        setup_requires = ['cffi>=1.0.0'],
+        tests_require= requires + ['pytest', 'numpy', 'pytz', 'pandas', 'ipython', 'tzlocal'],
+        setup_requires = ['cffi>=1.0.0', 'pytest-runner'],
         cffi_modules = ['rpy/_rinterface_cffi_build.py:ffibuilder'],
         package_dir = pack_dir,
         packages = [pack_name,


### PR DESCRIPTION
This solves:

 * https://bitbucket.org/rpy2/rpy2/issues/551/missing-test-dependencies
 * https://bitbucket.org/rpy2/rpy2/issues/552/running-test-suite-gives-import-error

First by listing all required test dependencies, secondly by properly enabling the pytest/setuptools integration:

https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner