### PR TITLE
make html target depend on notebooks

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -92,7 +92,7 @@ _notebooks_rst: $(MD_NOTEBOOKS:%=notebooks/%.rst)
 
 notebooks: _ensure_notebooks_dir _notebooks _notebooks_html _notebooks_rst
 
-html:
+html: notebooks
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,4 @@
+jupyter_client
+notebook
+notedown
+sphinx


### PR DESCRIPTION
This makes sure the notebooks are build before building the HTML pages.

Also adds a `requirements.txt` file which specifies required python dependencies, used with `pip install -r requirements.txt`