### PR TITLE
Fix test_initr on macOS with Python 3.8

### DIFF
--- a/rpy2/tests/rinterface/test_embedded_r.py
+++ b/rpy2/tests/rinterface/test_embedded_r.py
@@ -72,12 +72,14 @@ def test_set_initoptions_after_init():
                                              '--no-save'))
 
 
+def _init_r():
+    from rpy2 import rinterface
+    rinterface.initr()
+
+
 def test_initr():
-    def init_r():
-        from rpy2 import rinterface
-        rinterface.initr()
     preserve_hash = True
-    proc = multiprocessing.Process(target=init_r,
+    proc = multiprocessing.Process(target=_init_r,
                                    args=(preserve_hash,))
     proc.start()
     proc.join()


### PR DESCRIPTION
Probably due to https://github.com/python/cpython/pull/13603, this test fails on macOS + Python 3.8 with
```
    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       AttributeError: Can't pickle local object 'test_initr.<locals>.init_r'
```
xref: https://github.com/conda-forge/rpy2-feedstock/pull/39#discussion_r352114646