### PR TITLE
Fix issue #77 (again).

### DIFF
--- a/rpy2/robjects/__init__.py
+++ b/rpy2/robjects/__init__.py
@@ -349,7 +349,7 @@ class R(object):
 
     def __new__(cls):
         if cls._instance is None:
-            rinterface.initr()
+            rinterface.initr_simple()
             cls._instance = object.__new__(cls)
         return cls._instance
 

--- a/rpy2/robjects/robject.py
+++ b/rpy2/robjects/robject.py
@@ -7,7 +7,7 @@ import rpy2.rinterface_lib.callbacks
 
 from . import conversion
 
-rpy2.rinterface.initr()
+rpy2.rinterface.initr_simple()
 
 
 class RSlots(object):


### PR DESCRIPTION
The function `initr_simple()` is called instead of `initr()` to
initialize R. This will ensure that the embedded R is ended when
the Python process exits.