### PR TITLE
FIX: byte-object has to be unicode string

### DIFF
--- a/rpy2/ipython/rmagic.py
+++ b/rpy2/ipython/rmagic.py
@@ -487,7 +487,7 @@ class RMagics(Magics):
             # -- empty ones are not published
             if stat(imgfile).st_size >= 1000:
                 with open(imgfile, 'rb') as fh_img:
-                    images.append(fh_img.read())
+                    images.append(fh_img.read().decode())
 
         mimetypes = {'png': 'image/png', 'svg': 'image/svg+xml'}
         mime = mimetypes[self.device]


### PR DESCRIPTION
An SVG plot in R is not shown in Jupyter because the SVG content is still a byte-object instead of a unicode string. 

Plotting SVG was enabled by setting:
%Rdevice svg
%R options(jupyter.plot_mimetypes = "image/svg+xml")
