### PR TITLE
setup.py: Print CFFI configuration messages only on build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 from rpy2 import situation
 
 from setuptools import setup
+from distutils.command.build import build as du_build
 
 PACKAGE_NAME = 'rpy2'
 pack_version = __import__('rpy2').__version__
@@ -111,7 +112,6 @@ def get_r_c_extension_status():
 
 
 cffi_mode = situation.get_cffi_mode()
-print('cffi mode: %s' % cffi_mode)
 c_extension_status = get_r_c_extension_status()
 if cffi_mode == situation.CFFI_MODE.ABI:
     cffi_modules = ['rpy2/_rinterface_cffi_build.py:ffibuilder_abi']
@@ -134,6 +134,30 @@ elif cffi_mode == situation.CFFI_MODE.ANY:
 else:
     # This should never happen.
     raise ValueError('Invalid value for cffi_mode')
+
+class build(du_build):
+
+    def run(self):
+        print('cffi mode: %s' % cffi_mode)
+
+        du_build.run(self)
+
+        print('---')
+        print(cffi_mode)
+        if cffi_mode in (situation.CFFI_MODE.ABI,
+                         situation.CFFI_MODE.BOTH,
+                         situation.CFFI_MODE.ANY):
+            print('ABI mode interface built.')
+        if cffi_mode in (situation.CFFI_MODE.API,
+                         situation.CFFI_MODE.BOTH):
+            print('API mode interface built.')
+        if cffi_mode == situation.CFFI_MODE.ANY:
+            if c_extension_status == COMPILATION_STATUS.OK:
+                print('API mode interface built.')
+            else:
+                print('API mode interface not built because: %s' % c_extension_status)
+        print('To change the API/ABI build mode, set or modify the environment '
+              'variable RPY2_CFFI_MODE.')
 
 LONG_DESCRIPTION = """
 Python interface to the R language.
@@ -168,6 +192,7 @@ if __name__ == '__main__':
         install_requires=requires + ['cffi>=1.10.0'],
         setup_requires=['cffi>=1.10.0'],
         cffi_modules=cffi_modules,
+        cmdclass = dict(build=build),
         package_dir=pack_dir,
         packages=([PACKAGE_NAME] +
                   ['{pack_name}.{x}'.format(pack_name=PACKAGE_NAME, x=x)
@@ -193,20 +218,3 @@ if __name__ == '__main__':
         package_data={'rpy2': ['rinterface_lib/R_API.h',
                                'rinterface_lib/R_API_eventloop.h']}
     )
-
-    print('---')
-    print(cffi_mode)
-    if cffi_mode in (situation.CFFI_MODE.ABI,
-                     situation.CFFI_MODE.BOTH,
-                     situation.CFFI_MODE.ANY):
-        print('ABI mode interface built and installed.')
-    if cffi_mode in (situation.CFFI_MODE.API,
-                     situation.CFFI_MODE.BOTH):
-        print('API mode interface built and installed.')
-    if cffi_mode == situation.CFFI_MODE.ANY:
-        if c_extension_status == COMPILATION_STATUS.OK:
-            print('API mode interface built and installed.')
-        else:
-            print('API mode interface not build because: %s' % c_extension_status)
-    print('To change the API/ABI build mode, set or modify the environment '
-          'variable RPY2_CFFI_MODE.')


### PR DESCRIPTION
Currently `setup.py` emits messages regarding CFFI modes on all commands, even on `setup.py sdist`. This is nonstandard.

