### PR TITLE
 Restore Ctrl+C to interrupt (issue #723)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,9 @@ Bugs fixed
   now wrapped in `R_ToplevelExec()` to limit the propagation
   of R exceptions. This solved issue #710.
 
+- Initializing the embedded R caused the loss of ability to use Ctrl-C
+  to send SIGINT to a Python process (issue #723)
+
 
 Release 3.3.6
 =============

--- a/rpy2/rinterface.py
+++ b/rpy2/rinterface.py
@@ -1,6 +1,7 @@
 import atexit
 import os
 import math
+import signal
 import typing
 from typing import Union
 from rpy2.rinterface_lib import openrlib
@@ -31,6 +32,10 @@ if os.name == 'nt':
 R_NilValue = openrlib.rlib.R_NilValue
 
 endr = embedded.endr
+
+
+def _sigint_handler(sig, frame):
+    raise KeyboardInterrupt()
 
 
 @_cdata_res_to_rinterface
@@ -860,6 +865,8 @@ def _post_initr_setup() -> None:
             [openrlib.rlib.R_NaReal, openrlib.rlib.R_NaReal])
     )
     NA_Complex = na_values.NA_Complex
+
+    signal.signal(signal.SIGINT, _sigint_handler)
 
 
 def rternalize(function: typing.Callable) -> SexpClosure:


### PR DESCRIPTION
Adding signal handler for SIGINT after R initialization seems like the simplest initial way to address the issue.

Preventing the embedded R from taking over Ctrl+C would be more elegant but I do not know whether it is possible. The way rpy2 initializes the embedded R with `R_SignalHandlers = 0`. I initially had understood that no R handling would happen, but I did not think that R would actively remove an existing handler to enforce that nothing would happen.