### PR TITLE
enh: look for R path in HKEY_CURRENT_USER (Windows registry)

### DIFF
--- a/rpy2/situation.py
+++ b/rpy2/situation.py
@@ -88,7 +88,14 @@ def r_home_from_registry() -> Optional[str]:
         r_home = winreg.QueryValueEx(hkey, 'InstallPath')[0]
         winreg.CloseKey(hkey)
     except Exception:  # FileNotFoundError, WindowsError, etc
-        return None
+        try:
+            hkey = winreg.OpenKeyEx(winreg.HKEY_CURRENT_USER,
+                                    'Software\\R-core\\R',
+                                    0, winreg.KEY_QUERY_VALUE)
+            r_home = winreg.QueryValueEx(hkey, 'InstallPath')[0]
+            winreg.CloseKey(hkey)
+        except Exception:  # FileNotFoundError, WindowsError, etc
+            return None
     if sys.version_info[0] == 2:
         r_home = r_home.encode(sys.getfilesystemencoding())
     return r_home


### PR DESCRIPTION
On Windows, R can be installed by a user (not admin) in which case the binary is installed in the user's home directory. In addition, the R installer edits the registry in "HKEY_CURRENT_USER" instead of in "HKEY_LOCAL_MACHINE". This PR makes rpy2 also look in "HKEY_CURRENT_USER".