### PR TITLE
Only (re)set the signal handler for SIGINT if main thread (issue #769).

### DIFF
--- a/rpy2/rinterface.py
+++ b/rpy2/rinterface.py
@@ -951,7 +951,7 @@ def _post_initr_setup() -> None:
                 raise ve
     else:
         warn_about_thread = True
-    if  warn_about_thread:
+    if warn_about_thread:
         warnings.warn(
             textwrap.dedent(
                 """R is not initialized by the main thread.

--- a/rpy2/rinterface.py
+++ b/rpy2/rinterface.py
@@ -4,7 +4,10 @@ import os
 import math
 import platform
 import signal
+import textwrap
+import threading
 import typing
+import warnings
 from typing import Union
 from rpy2.rinterface_lib import openrlib
 import rpy2.rinterface_lib._rinterface_capi as _rinterface
@@ -937,7 +940,28 @@ def _post_initr_setup() -> None:
     )
     NA_Complex = na_values.NA_Complex
 
-    signal.signal(signal.SIGINT, _sigint_handler)
+    warn_about_thread = False
+    if threading.current_thread() is threading.main_thread():
+        try:
+            signal.signal(signal.SIGINT, _sigint_handler)
+        except ValueError as ve:
+            if str(ve) == 'signal only works in main thread':
+                warn_about_thread = True
+            else:
+                raise ve
+    else:
+        warn_about_thread = True
+    if  warn_about_thread:
+        warnings.warn(
+            textwrap.dedent(
+                """R is not initialized by the main thread.
+                Its taking over SIGINT cannot be reversed here, and as a
+                consequence the embedded R cannot be interrupted with Ctrl-C.
+                Consider (re)setting the signal handler of your choice from
+                the main thread."""
+            )
+        )
+
     _update_R_ENC_PY()
 
 

--- a/rpy2/tests/rinterface/test_threading.py
+++ b/rpy2/tests/rinterface/test_threading.py
@@ -1,16 +1,43 @@
 import pytest
-from rpy2 import rinterface
+import rpy2.rinterface
+import rpy2.rinterface_lib.embedded
+from threading import Thread
 from rpy2.rinterface import embedded
 
 
-def rpy2_init():
-    from rpy2.rinterface_lib.embedded import _initr
-    _initr()
+class ThreadWithExceptions(Thread):
+    """Wrapper around Thread allowing to record exceptions from the thread."""
+
+    def run(self):
+        self.exception = None
+        try:
+            self._target()
+        except Exception as e:
+            self.exception = e
+
 
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
                     reason='Can only be tested before R is initialized.')
-def test_threading():
-    from threading import Thread
-
-    thread = Thread(target=rpy2_init)
+def test_threading__initr():
+    thread = ThreadWithExceptions(target=rpy2.rinterface_lib.embedded._initr)
     thread.start()
+    thread.join()
+    assert not thread.exception
+
+
+@pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
+                    reason='Can only be tested before R is initialized.')
+def test_threading_initr_simple():
+    # This initialization performs more post-initialization setup compared to _initr.
+    # It will check whether R is initialized from the main thread.
+    thread = ThreadWithExceptions(target=rpy2.rinterface.initr_simple)
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r'R is not initialized by the main thread.\n'
+            r'\W+Its taking over SIGINT cannot be reversed here.+'
+        )
+    ):
+        thread.start()
+        thread.join()
+    assert not thread.exception

--- a/scripts/run_test_min_deps.sh
+++ b/scripts/run_test_min_deps.sh
@@ -25,6 +25,16 @@ pytest \
     --cov=rpy2.rinterface_lib.embedded \
     rpy2/tests/rinterface/test_endr.py
 
+for testname in test_threading__initr test_threading_initr_simple; do
+  pytest \
+      --cov-append \
+      --cov-report=xml \
+      --cov-report=term \
+      --cov=rpy2.rinterface_lib.embedded \
+      rpy2/tests/rinterface/test_threading.py -k "${testname}"
+done
+
+# Added in case the loop above is not updated and is missing tests
 pytest \
     --cov-append \
     --cov-report=xml \


### PR DESCRIPTION
Adding a unit test that covers the case triggering the issue would probably be good.