### PR TITLE
Add test for issue signal registration in a thread

### DIFF
--- a/rpy2/tests/rinterface/test_threading.py
+++ b/rpy2/tests/rinterface/test_threading.py
@@ -1,16 +1,8 @@
 import pytest
+import rpy2.rinterface
+import rpy2.rinterface_lib.embedded
 from threading import Thread
 from rpy2.rinterface import embedded
-
-
-def rpy2_init():
-    from rpy2.rinterface_lib.embedded import _initr
-    _initr()
-
-
-def rpy2_init_simple():
-    from rpy2.rinterface import initr_simple
-    initr_simple()
 
 
 class ThreadWithExceptions(Thread):
@@ -27,7 +19,7 @@ class ThreadWithExceptions(Thread):
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
                     reason='Can only be tested before R is initialized.')
 def test_threading():
-    thread = ThreadWithExceptions(target=rpy2_init)
+    thread = ThreadWithExceptions(target=rpy2.rinterface_lib.embedded._initr)
     thread.start()
     thread.join()
     assert not thread.exception
@@ -36,7 +28,7 @@ def test_threading():
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
                     reason='Can only be tested before R is initialized.')
 def test_threading_signal():
-    thread = ThreadWithExceptions(target=rpy2_init_simple)
+    thread = ThreadWithExceptions(target=rpy2.rinterface.initr_simple)
     with pytest.warns(
         UserWarning,
         match=(

--- a/rpy2/tests/rinterface/test_threading.py
+++ b/rpy2/tests/rinterface/test_threading.py
@@ -1,5 +1,5 @@
 import pytest
-from rpy2 import rinterface
+from threading import Thread
 from rpy2.rinterface import embedded
 
 
@@ -7,10 +7,43 @@ def rpy2_init():
     from rpy2.rinterface_lib.embedded import _initr
     _initr()
 
+
+def rpy2_init_simple():
+    from rpy2.rinterface import initr_simple
+    initr_simple()
+
+
+class ThreadWithExceptions(Thread):
+    """Wrapper around Thread allowing to record exceptions from the thread."""
+
+    def run(self):
+        self.exception = None
+        try:
+            self._target()
+        except Exception as e:
+            self.exception = e
+
+
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
                     reason='Can only be tested before R is initialized.')
 def test_threading():
-    from threading import Thread
-
-    thread = Thread(target=rpy2_init)
+    thread = ThreadWithExceptions(target=rpy2_init)
     thread.start()
+    thread.join()
+    assert not thread.exception
+
+
+@pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
+                    reason='Can only be tested before R is initialized.')
+def test_threading_signal():
+    thread = ThreadWithExceptions(target=rpy2_init_simple)
+    with pytest.warns(
+        UserWarning,
+        match=(
+            r'R is not initialized by the main thread.\n'
+            r'\W+Its taking over SIGINT cannot be reversed here.+'
+        )
+    ):
+        thread.start()
+        thread.join()
+    assert not thread.exception

--- a/rpy2/tests/rinterface/test_threading.py
+++ b/rpy2/tests/rinterface/test_threading.py
@@ -18,7 +18,7 @@ class ThreadWithExceptions(Thread):
 
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
                     reason='Can only be tested before R is initialized.')
-def test_threading():
+def test_threading__initr():
     thread = ThreadWithExceptions(target=rpy2.rinterface_lib.embedded._initr)
     thread.start()
     thread.join()
@@ -27,7 +27,9 @@ def test_threading():
 
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
                     reason='Can only be tested before R is initialized.')
-def test_threading_signal():
+def test_threading_initr_simple():
+    # This initialization performs more post-initialization setup compared to _initr.
+    # It will check whether R is initialized from the main thread.
     thread = ThreadWithExceptions(target=rpy2.rinterface.initr_simple)
     with pytest.warns(
         UserWarning,

--- a/scripts/run_test_min_deps.sh
+++ b/scripts/run_test_min_deps.sh
@@ -25,6 +25,16 @@ pytest \
     --cov=rpy2.rinterface_lib.embedded \
     rpy2/tests/rinterface/test_endr.py
 
+for testname in test_threading__initr test_threading_initr_simple; do
+  pytest \
+      --cov-append \
+      --cov-report=xml \
+      --cov-report=term \
+      --cov=rpy2.rinterface_lib.embedded \
+      rpy2/tests/rinterface/test_threading.py -k "${testname}"
+done
+
+# Added in case the loop above is not updated and is missing tests
 pytest \
     --cov-append \
     --cov-report=xml \


### PR DESCRIPTION
Adding a test for #769; added a thin wrapper around `Thread` as otherwise the test case would pass even though the exception would be written to standard error silently (there are other more complex [solutions possible](https://stackoverflow.com/questions/2829329/catch-a-threads-exception-in-the-caller-thread-in-python/31614591), but I wanted to keep as simple as possible here).