### PR TITLE
Interrupt embedded R during execution when Python is interrupted.

### DIFF
--- a/rpy2/rinterface_lib/R_API.h
+++ b/rpy2/rinterface_lib/R_API.h
@@ -356,6 +356,9 @@ typedef enum {
 
 SEXP R_ParseVector(SEXP text, int num, ParseStatus *status, SEXP srcfile);
 
+/* include/Defn.h */
+extern int R_interrupts_pending;
+
 /* include/Rinterface.h */
 extern Rboolean R_Interactive ;
 extern void* R_GlobalContext;

--- a/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2/rinterface_lib/callbacks.py
@@ -7,6 +7,7 @@ that makes it possible."""
 from contextlib import contextmanager
 import logging
 import typing
+import os
 from rpy2.rinterface_lib import openrlib
 from rpy2.rinterface_lib import ffi_proxy
 from rpy2.rinterface_lib import conversion
@@ -276,6 +277,14 @@ _PROCESSEVENTS_EXCEPTION_LOG = 'R[processevents]: %s'
 def _processevents() -> None:
     try:
         processevents()
+    except KeyboardInterrupt:
+        # Mirroring cross-platform interruption of embedded R from Rstudio
+        # https://github.com/rstudio/rstudio/blob/2853a5/src/cpp/r/RExec.cpp#L590-L599
+        rlib = openrlib.rlib
+        if os.name == 'nt':
+            rlib.UserBreak = 1
+        else:
+            rlib.R_interrupts_pending = 1
     except Exception as e:
         logger.error(_PROCESSEVENTS_EXCEPTION_LOG, str(e))
 

--- a/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2/rinterface_lib/callbacks.py
@@ -278,18 +278,18 @@ def _processevents() -> None:
     try:
         processevents()
     except KeyboardInterrupt:
-        # This function is a Python callback. A keyboard interruption is captured
-        # in Python, but R must be notified that an interruption occured so it
-        # can handle it.
+        # This function is a Python callback. A keyboard interruption is
+        # captured in Python, but R must be notified that an interruption
+        # occured so it can handle it.
         rlib = openrlib.rlib
         if os.name == 'nt':
-            # On Windows, the global C-level R variable `UserBreak` is set to one
-            # to notifying R that a `SIGBREAK` has been sent
+            # On Windows, the global C-level R variable `UserBreak` is set
+            # to one to notifying R that a `SIGBREAK` has been sent
             # (see the R source - `src/gnuwin32/embeddedR.c:my_onintr()`).
             rlib.UserBreak = 1
         else:
-            # On UNIX-like, R can be notified that a SIGINT has been sent through
-            # the C-level R variable `R_interrupts_pending`
+            # On UNIX-like, R can be notified that a SIGINT has been sent
+            # through the C-level R variable `R_interrupts_pending`
             # (see the R source - `src/main/main.c:handleInterrupt()`)
             rlib.R_interrupts_pending = 1
     except Exception as e:

--- a/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2/rinterface_lib/callbacks.py
@@ -278,12 +278,19 @@ def _processevents() -> None:
     try:
         processevents()
     except KeyboardInterrupt:
-        # Mirroring cross-platform interruption of embedded R from Rstudio
-        # https://github.com/rstudio/rstudio/blob/2853a5/src/cpp/r/RExec.cpp#L590-L599
+        # This function is a Python callback. A keyboard interruption is captured
+        # in Python, but R must be notified that an interruption occured so it
+        # can handle it.
         rlib = openrlib.rlib
         if os.name == 'nt':
+            # On Windows, the global C-level R variable `UserBreak` is set to one
+            # to notifying R that a `SIGBREAK` has been sent
+            # (see the R source - `src/gnuwin32/embeddedR.c:my_onintr()`).
             rlib.UserBreak = 1
         else:
+            # On UNIX-like, R can be notified that a SIGINT has been sent through
+            # the C-level R variable `R_interrupts_pending`
+            # (see the R source - `src/main/main.c:handleInterrupt()`)
             rlib.R_interrupts_pending = 1
     except Exception as e:
         logger.error(_PROCESSEVENTS_EXCEPTION_LOG, str(e))

--- a/rpy2/tests/rinterface/test_embedded_r.py
+++ b/rpy2/tests/rinterface/test_embedded_r.py
@@ -171,6 +171,7 @@ def testExternalPythonFromExpression():
 
 
 def testInterruptR():
+    expected_code = 42  # this is an arbitrary exit code that we check for below
     with tempfile.NamedTemporaryFile(mode='w', suffix='.py',
                                      delete=False) as rpy_code:
         rpy2_path = os.path.dirname(rpy2.__path__[0])
@@ -193,8 +194,8 @@ def testInterruptR():
         try:
             ri.baseenv['eval'](ri.parse(rcode))
         except Exception as e:
-            sys.exit(0)
-      """ % rpy2_path
+            sys.exit(%d)
+      """ % (rpy2_path, expected_code)
 
         rpy_code.write(rpy_code_str)
     cmd = (sys.executable, rpy_code.name)
@@ -213,7 +214,7 @@ def testInterruptR():
         child_proc.send_signal(sigint)
         time.sleep(1)  # required for the SIGINT to function
         ret_code = child_proc.poll()
-    assert ret_code is not None  # Interruption failed
+    assert ret_code == expected_code  # Interruption failed
 
 
 # TODO: still needed ?

--- a/rpy2/tests/rinterface/test_embedded_r.py
+++ b/rpy2/tests/rinterface/test_embedded_r.py
@@ -171,21 +171,18 @@ def testExternalPythonFromExpression():
     xp = rinterface.baseenv['vector'](xp_name, 3)
 
 
-def test_interrupt_r_compute():
-    do_test_interrupt('while(TRUE) {}')
-
-
-def test_interrupt_r_compute_with_sleep():
-    do_test_interrupt('''
-    i <- 0;
-    while(TRUE) {
-      i <- i+1;
-      Sys.sleep(0.01);
-    }
-    ''')
-
-
-def do_test_interrupt(rcode):
+@pytest.mark.parametrize(
+    'rcode',
+    ('while(TRUE) {}',
+     """
+     i <- 0;
+     while(TRUE) {
+       i <- i+1;
+       Sys.sleep(0.01);
+     }
+     """)
+)
+def test_interrupt_r(rcode):
     expected_code = 42  # this is an arbitrary exit code that we check for below
     with tempfile.NamedTemporaryFile(mode='w', suffix='.py',
                                      delete=False) as rpy_code:

--- a/rpy2/tests/rinterface/test_embedded_r.py
+++ b/rpy2/tests/rinterface/test_embedded_r.py
@@ -203,7 +203,8 @@ def do_test_interrupt(rcode):
             # This flush is important to make sure we avoid a deadlock.
             print(x, flush=True)
         rcode = '''
-        writeLines('executing-rcode');
+        message('executing-rcode')
+        console.flush()
         %s
         '''
         with callbacks.obj_in_module(callbacks, 'consolewrite_print', f):


### PR DESCRIPTION
**Edit**: I've updated this PR to fix the issue noted in #831 by ensuring interrupt signals in the Python process result in an interruption of the embedded R instance. I've also updated unit tests to make sure there's a check for this (by showing that `while(T){}` can be interrupted).

Previous message:

This PR fixes an existing unit test for interrupting R code. Here's the description in commit 18ae4ff:

There are two issues in the existing test:
- The python source code is indented, fixed by using `textwrap.dedent()`.
- It seems to change console writing using an old method that doesn't exist (thus throwing an error); Not sure how critical this is to implement, but I've mirrored the code to do this from `test_set_consolewrite_print`.

I also make the exception in the test more specific, an RRuntimeError, which is what I see when testing the feature locally.

While not critical to fixing the test, I tried to clean up the code used to check the child process return code by swapping `time.sleep()` and `child_proc.poll()` out for `child_proc.wait()`. This should achieve what the old code did, but may let the test complete earlier if the child responds quickly enough to the SIGINT. For test failures, this will wind up throwing a `TimeoutError` (instead of an assertion failure with `ret_code=None` as it does before this change).