### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,9 @@ if __name__ == '__main__':
         long_description=LONG_DESCRIPTION,
         url='https://rpy2.github.io',
         project_urls={
+            'Documentation': 'https://rpy2.github.io/doc.html'
             'Source': 'https://github.com/rpy2/rpy2',
+            'Tracker': 'https://github.com/rpy2/rpy2/issues'
         },
         license='GPLv2+',
         author='Laurent Gautier',

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
         long_description=LONG_DESCRIPTION,
         url='https://rpy2.github.io',
         project_urls={
-            'Documentation': 'https://rpy2.github.io/doc.html'
+            'Documentation': 'https://rpy2.github.io/doc.html',
             'Source': 'https://github.com/rpy2/rpy2',
             'Tracker': 'https://github.com/rpy2/rpy2/issues'
         },

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,9 @@ if __name__ == '__main__':
         description='Python interface to the R language (embedded R)',
         long_description=LONG_DESCRIPTION,
         url='https://rpy2.github.io',
+        project_urls={
+            "Source": "https://github.com/rpy2/rpy2",
+        },
         license='GPLv2+',
         author='Laurent Gautier',
         author_email='lgautier@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
         long_description=LONG_DESCRIPTION,
         url='https://rpy2.github.io',
         project_urls={
-            "Source": "https://github.com/rpy2/rpy2",
+            'Source': 'https://github.com/rpy2/rpy2',
         },
         license='GPLv2+',
         author='Laurent Gautier',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)