### PR TITLE
Fix segfault with `__getitem__`.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,9 @@ Bugs fixed
 - The :mod:`rpy2.rinterface`-level conversion of Python integers to R integers is now
   checking that integers are not larger than what R can handle.
   
+- Trying to access items in an R environment before R is initialized is no
+  longer ending with a segfault (issue #842).
+
 
 Release 3.4.6
 =============

--- a/rpy2/rinterface_lib/sexp.py
+++ b/rpy2/rinterface_lib/sexp.py
@@ -364,6 +364,7 @@ class SexpEnvironment(Sexp):
             raise TypeError('The key must be a non-empty string.')
         elif not len(key):
             raise ValueError('The key must be a non-empty string.')
+        assert embedded.isinitialized()
         with memorymanagement.rmemory() as rmemory:
             key_cchar = conversion._str_to_cchar(key)
             symbol = rmemory.protect(

--- a/rpy2/rinterface_lib/sexp.py
+++ b/rpy2/rinterface_lib/sexp.py
@@ -364,7 +364,7 @@ class SexpEnvironment(Sexp):
             raise TypeError('The key must be a non-empty string.')
         elif not len(key):
             raise ValueError('The key must be a non-empty string.')
-        assert embedded.isinitialized()
+        embedded.assert_isready()
         with memorymanagement.rmemory() as rmemory:
             key_cchar = conversion._str_to_cchar(key)
             symbol = rmemory.protect(

--- a/rpy2/tests/rinterface/test_noinitialization.py
+++ b/rpy2/tests/rinterface/test_noinitialization.py
@@ -1,6 +1,7 @@
 import pytest
 from rpy2 import rinterface
 from rpy2.rinterface import embedded
+from rpy2.rinterface_lib import sexp
 
 
 @pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
@@ -22,3 +23,8 @@ def test_assert_isready():
     with pytest.raises(embedded.RNotReadyError):
         embedded.assert_isready()
 
+@pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
+                    reason='Can only be tested before R is initialized.')
+def test_assert_environment_geitem():
+    with pytest.raises(embedded.RNotReadyError):
+        sexp.globalenv['x']


### PR DESCRIPTION
Calling `__getitem__` on an R environment will segfault if R is uninitialized.

Fix for issue #842.