### PR TITLE
Add C-extension to work limitations in memoryview.cast().

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -40,7 +40,7 @@ jobs:
         python -m pip install setuptools wheel twine
     - name: Build wheel
       run: |
-        python setup.py bdist_wheel
+        pip wheel -w dist --no-deps -e .
     - name: Build sdist
       if: (matrix.r-version == '4.0' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8')
       run: |

--- a/NEWS
+++ b/NEWS
@@ -58,10 +58,14 @@ Changes
   use of the context variable should address issues when using nested
   :meth:`rpy2.rinterface.local_context`.
 
-
 - Added recommendation to try :meth:`pandas.DataFrame.infer_objects` when
   the converion to R data frames fails because of mixed types (issue #794).
 
+- No longer implicit dependency on :mod:`numpy` for memory views. The Python
+  API has an unresolved issue around handling FORTRAN-ordered arrays without
+  going to C-level (https://bugs.python.org/issue34778), and C-extension
+  as added to rpy2 to cut the dependency on numpy for just this (PR #856).
+   
 Bugs fixed
 ----------
 

--- a/rpy2/rinterface_lib/_bufferprotocol.c
+++ b/rpy2/rinterface_lib/_bufferprotocol.c
@@ -5,31 +5,30 @@
 static PyObject *
 memoryview_swapstrides(PyObject *self, PyObject *args)
 {
-    Py_buffer *view;
-    PyObject *memoryview;
-
-    if (!PyArg_ParseTuple(args, "O",
-			  &memoryview)) {
-        return NULL;
-    }
-
-    if (!PyMemoryView_Check(memoryview)) {
-      PyErr_SetString(PyExc_ValueError, "obj must be a memoryview.");
-      return NULL;
-    }
-    view = PyMemoryView_GET_BUFFER(memoryview);
-    if (!PyBuffer_IsContiguous(view, 'A')) {
-      PyErr_SetString(PyExc_ValueError, "obj must have a continuous buffer.");
-      return NULL;
-    }
-    int ndim = view->ndim;
-    Py_ssize_t prev_dim = 1;
-    for (Py_ssize_t i=0; i < ndim; i++) {
-      view->strides[i] = view->itemsize*prev_dim;
-      prev_dim = view->shape[i];
-    }
-    ((PyMemoryViewObject *)memoryview)->flags |= PyBUF_F_CONTIGUOUS;
-    return Py_None;
+  Py_buffer *view;
+  PyObject *memoryview;
+  
+  if (!PyArg_ParseTuple(args, "O",
+			&memoryview)) {
+    return NULL;
+  }
+  
+  if (!PyMemoryView_Check(memoryview)) {
+    PyErr_SetString(PyExc_ValueError, "obj must be a memoryview.");
+    return NULL;
+  }
+  view = PyMemoryView_GET_BUFFER(memoryview);
+  if (!PyBuffer_IsContiguous(view, 'A')) {
+    PyErr_SetString(PyExc_ValueError, "obj must have a continuous buffer.");
+    return NULL;
+  }
+  int ndim = view->ndim;
+  Py_ssize_t prod_prev_dim = 1;
+  for (Py_ssize_t i=0; i < ndim; i++) {
+    view->strides[i] = view->itemsize*prod_prev_dim;
+    prod_prev_dim *= view->shape[i];
+  }
+  return Py_None;
 };
 
 

--- a/rpy2/rinterface_lib/_bufferprotocol.c
+++ b/rpy2/rinterface_lib/_bufferprotocol.c
@@ -1,0 +1,56 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
+static PyObject *
+memoryview_fordered(PyObject *self, PyObject *args)
+{
+    const char *cast_str;
+    Py_buffer view;
+    PyObject *shape;
+    PyObject *memoryview;
+    Py_ssize_t tmp_stride;
+    int ndim;
+
+    if (!PyArg_ParseTuple(args, "OsO!",
+			  &memoryview,
+			  &cast_str,
+			  &PyTuple_Type, &shape))
+        return NULL;
+
+    int status = PyObject_GetBuffer(memoryview, &view,
+				    PyBUF_WRITABLE | PyBUF_FORMAT |
+				    PyBUF_STRIDES | PyBUF_F_CONTIGUOUS);
+    // test status
+    ndim = view.ndim;
+    for (int i=0; i < (ndim/2); i++) {
+      tmp_stride = view.strides[ndim - i];
+      view.strides[ndim - i] = view.strides[i];
+      view.strides[i] = tmp_stride;
+    }
+    PyBuffer_Release(&view);
+    return Py_None;
+};
+
+
+static PyMethodDef _BufferProtocolMethods[] =
+  {
+   {"memoryview_fordered", memoryview_fordered, METH_VARARGS,
+    "Set the strides to be Fortran-ordered."},
+   {NULL, NULL, 0, NULL}
+  };
+
+
+static struct PyModuleDef _bufferprotocolmodule = {
+  PyModuleDef_HEAD_INIT,
+  "_bufferprotocol",
+  NULL, //_bufferprotocol_doc,
+  -1,
+  _BufferProtocolMethods
+};
+
+PyMODINIT_FUNC
+PyInit__bufferprotocol(void)
+{
+  return PyModule_Create(&_bufferprotocolmodule);  
+};

--- a/rpy2/rinterface_lib/_bufferprotocol.c
+++ b/rpy2/rinterface_lib/_bufferprotocol.c
@@ -28,6 +28,7 @@ memoryview_swapstrides(PyObject *self, PyObject *args)
     view->strides[i] = view->itemsize*prod_prev_dim;
     prod_prev_dim *= view->shape[i];
   }
+  ((PyMemoryViewObject *)memoryview)->flags |= PyBUF_F_CONTIGUOUS;
   return Py_None;
 };
 

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,10 @@ elif cffi_mode == situation.CFFI_MODE.API:
         print('API mode requested but %s' % c_extension_status.value)
         sys.exit(1)
     cffi_modules = ['rpy2/_rinterface_cffi_build.py:ffibuilder_api']
-    ext_modules = [Extension('rpy2.rinterface_lib._bufferprotocol',
-                             ['rpy2/rinterface_lib/_bufferprotocol.c'])]
+    ext_modules = [
+        Extension('rpy2.rinterface_lib._bufferprotocol',
+                  ['rpy2/rinterface_lib/_bufferprotocol.c'])
+    ]
 elif cffi_mode == situation.CFFI_MODE.BOTH:
     if c_extension_status != COMPILATION_STATUS.OK:
         print('API mode requested but %s' % c_extension_status.value)
@@ -135,8 +137,10 @@ elif cffi_mode == situation.CFFI_MODE.ANY:
     cffi_modules = ['rpy2/_rinterface_cffi_build.py:ffibuilder_abi']
     if c_extension_status == COMPILATION_STATUS.OK:
         cffi_modules.append('rpy2/_rinterface_cffi_build.py:ffibuilder_api')
-        ext_modules = [Extension('rpy2.rinterface_lib._bufferprotocol',
-                                 ['rpy2/rinterface_lib/_bufferprotocol.c'])]
+        ext_modules = [
+            Extension('rpy2.rinterface_lib._bufferprotocol',
+                      ['rpy2/rinterface_lib/_bufferprotocol.c'])
+        ]
 else:
     # This should never happen.
     raise ValueError('Invalid value for cffi_mode')
@@ -198,7 +202,8 @@ if __name__ == '__main__':
     extras_require = {
         'test': ['pytest'],
         'numpy': ['pandas'],
-        'pandas': ['numpy', 'pandas']
+        'pandas': ['numpy', 'pandas'],
+        'setup': ['setuptools']
     }
     extras_require['all'] = list(
         set(x for lst in extras_require.values()
@@ -220,7 +225,7 @@ if __name__ == '__main__':
         author_email='lgautier@gmail.com',
         install_requires=requires,
         extras_require=extras_require,
-        setup_requires=['cffi>=1.10.0'],
+        setup_requires=['cffi>=1.10.0', 'setuptools'],
         cffi_modules=cffi_modules,
         ext_modules=ext_modules,
         cmdclass = dict(build=build),

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import tempfile
 import warnings
 
 from distutils.ccompiler import new_compiler
+from distutils.core import Extension
 from distutils.sysconfig import customize_compiler
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
@@ -113,6 +114,7 @@ def get_r_c_extension_status():
 
 cffi_mode = situation.get_cffi_mode()
 c_extension_status = get_r_c_extension_status()
+ext_modules = []
 if cffi_mode == situation.CFFI_MODE.ABI:
     cffi_modules = ['rpy2/_rinterface_cffi_build.py:ffibuilder_abi']
 elif cffi_mode == situation.CFFI_MODE.API:
@@ -120,6 +122,8 @@ elif cffi_mode == situation.CFFI_MODE.API:
         print('API mode requested but %s' % c_extension_status.value)
         sys.exit(1)
     cffi_modules = ['rpy2/_rinterface_cffi_build.py:ffibuilder_api']
+    ext_modules = [Extension('rpy2.rinterface_lib._bufferprotocol',
+                             ['rpy2/rinterface_lib/_bufferprotocol.c'])]
 elif cffi_mode == situation.CFFI_MODE.BOTH:
     if c_extension_status != COMPILATION_STATUS.OK:
         print('API mode requested but %s' % c_extension_status.value)
@@ -131,6 +135,8 @@ elif cffi_mode == situation.CFFI_MODE.ANY:
     cffi_modules = ['rpy2/_rinterface_cffi_build.py:ffibuilder_abi']
     if c_extension_status == COMPILATION_STATUS.OK:
         cffi_modules.append('rpy2/_rinterface_cffi_build.py:ffibuilder_api')
+        ext_modules = [Extension('rpy2.rinterface_lib._bufferprotocol',
+                                 ['rpy2/rinterface_lib/_bufferprotocol.c'])]
 else:
     # This should never happen.
     raise ValueError('Invalid value for cffi_mode')
@@ -216,6 +222,7 @@ if __name__ == '__main__':
         extras_require=extras_require,
         setup_requires=['cffi>=1.10.0'],
         cffi_modules=cffi_modules,
+        ext_modules=ext_modules,
         cmdclass = dict(build=build),
         package_dir=pack_dir,
         packages=([PACKAGE_NAME] +
@@ -243,6 +250,7 @@ if __name__ == '__main__':
                                'rinterface_lib/R_API_eventloop.h',
                                'rinterface_lib/R_API_eventloop.c',
                                'rinterface_lib/RPY2.h',
+                               'rinterface_lib/_bufferprotocol.c',
                                'py.typed']},
         zip_safe=False
     )


### PR DESCRIPTION
Python does not allow to cast a contiguous memory region into from C ordered to F ordered (see https://bugs.python.org/issue34778). This is implementing a C function to force it.