### PR TITLE
pandas2ri - added named-vector-to-pandas conversion

### DIFF
--- a/rpy2/robjects/pandas2ri.py
+++ b/rpy2/robjects/pandas2ri.py
@@ -224,9 +224,24 @@ def py2rpy_pandasseries(obj):
     return res
 
 
+def _ri2py_vector(obj):
+    x = numpy2ri.rpy2py(obj)
+    try:
+        # if names is assigned, convert to pandas series
+        return pandas.Series(x, obj.names)
+    except:
+        # if dimnames assigned, it's a named matrix, convert to pandas dataframe
+        try:
+            rownames, colnames = obj.do_slot("dimnames")
+            x = pandas.DataFrame(x, index=rownames, columns=colnames)
+        finally:
+            # plain vector/matrix
+            return x
+    
+
 @rpy2py.register(SexpVector)
 def ri2py_vector(obj):
-    res = numpy2ri.rpy2py(obj)
+    res = _ri2py_vector(obj)
     return res
 
 
@@ -235,7 +250,7 @@ def rpy2py_floatvector(obj):
     if POSIXct.isrinstance(obj):
         return rpy2py(POSIXct(obj))
     else:
-        return numpy2ri.rpy2py(obj)
+        return _ri2py_vector(obj)
 
 
 @rpy2py.register(POSIXct)

--- a/rpy2/tests/robjects/test_pandas_conversions.py
+++ b/rpy2/tests/robjects/test_pandas_conversions.py
@@ -415,3 +415,19 @@ class TestPandasConversions(object):
                 if 'd' in robjects.globalenv:
                     del(robjects.globalenv['d'])
         assert ok
+
+    def test_ri2pandas_named_vector(self):
+        rdataf = robjects.r("c('a' = 5, 'b' = 6, 'c' = 7, 'd' = 8)")
+        with localconverter(default_converter + rpyp.converter) as cv:
+            pandas_df = cv.rpy2py(rdataf)
+        assert all(x == y for x, y in zip(rdataf.names, pandas_df.index))
+
+        rdataf = robjects.r['matrix'](robjects.FloatVector([4, 5, 1, 10, 8, 3]), 
+                                      nrow = 2, ncol = 3, byrow = True)
+        rdataf.rownames = robjects.StrVector(["Row 1", "Row 2"])
+        rdataf.colnames = robjects.StrVector(["Column 1", "Column 2", "Column 3"])
+        with localconverter(default_converter + rpyp.converter) as cv:
+            pandas_df = cv.rpy2py(rdataf)
+        assert all(x == y for x, y in zip(rdataf.rownames, pandas_df.index))
+        assert all(x == y for x, y in zip(rdataf.colnames, pandas_df.columns))
+


### PR DESCRIPTION
This PR adds conversion from R named vector to Pandas Series and R named matrix to Pandas DataFrame.

It resolves the issue I encountered while retrieving the fixed effect coefficients (named vector) from `lme4.fixef()` and CI matrices from `confint()` functions.

I have also added `test_ri2pandas_named_vector()` pytest function to test the changes.