### PR TITLE
r_home_from_registry() - updated for R 4.x.x

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -93,7 +93,6 @@ jobs:
       run: |
         echo "RSPM=\"https://packagemanager.rstudio.com/cran/__linux__/$(lsb_release -sc)/latest\"" >> $GITHUB_ENV
     - name: Install R dependencies
-      if: matrix.os != 'windows-latest'
       run: |
         install.packages(c("ggplot2", "dplyr", "tidyr", "dbplyr", "lazyeval", "rlang"))
       shell: Rscript {0}
@@ -103,6 +102,12 @@ jobs:
         ${{ matrix.ld_libpath }}
         ${{ matrix.venv_activate }}
         bash -e ./scripts/run_test_rdeps.sh
+    - name: Test with R deps (windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        ${{ matrix.ld_libpath }}
+        ${{ matrix.venv_activate }}
+        pytest --cache-clear --cov-append --cov-report=xml --cov-report=term --cov=rpy2.rinterface_lib --cov=rpy2.rinterface --cov=rpy2.rlike --cov=rpy2.robjects rpy2/tests/robjects/lib
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       if: matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.8' && matrix.r-version == 'release'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install package
       run: |
         ${{ matrix.venv_activate }}
-        pip install -e .
+        pip install .
         rm -r build/
     - name: Test with minimal dependencies
       run: |
@@ -93,10 +93,12 @@ jobs:
       run: |
         echo "RSPM=\"https://packagemanager.rstudio.com/cran/__linux__/$(lsb_release -sc)/latest\"" >> $GITHUB_ENV
     - name: Install R dependencies
+      if: matrix.os != 'windows-latest'
       run: |
         install.packages(c("ggplot2", "dplyr", "tidyr", "dbplyr", "lazyeval", "rlang"))
       shell: Rscript {0}
     - name: Test with R deps
+      if: matrix.os != 'windows-latest'
       run: |
         ${{ matrix.ld_libpath }}
         ${{ matrix.venv_activate }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cffi>=1.10.0
 jinja2
 pytz
 tzlocal
+packaging;platform_system=='Windows'

--- a/rpy2/rinterface_lib/openrlib.py
+++ b/rpy2/rinterface_lib/openrlib.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import platform
 import threading
 import typing
@@ -23,9 +24,12 @@ ffi = _rinterface_cffi.ffi
 # TODO: Separate the functions in the module from the side-effect of
 # finding R_HOME and opening the shared library.
 R_HOME = rpy2.situation.get_r_home()
-LD_LIBRARY_PATH = (rpy2.situation.r_ld_library_path_from_subprocess(R_HOME)
-                   if R_HOME is not None
-                   else '')
+if os.name != 'nt':
+    # not relevant for Windows? (https://stackoverflow.com/questions/72575015)
+    LD_LIBRARY_PATH = (
+        rpy2.situation.r_ld_library_path_from_subprocess(R_HOME)
+        if R_HOME is not None
+        else '')
 rlock = threading.RLock()
 
 

--- a/rpy2/situation.py
+++ b/rpy2/situation.py
@@ -108,18 +108,16 @@ def r_home_from_registry() -> Optional[str]:
                 def get_version(i):
                     try:
                         return Version(winreg.EnumKey(hkey, i))
-                    except:
+                    except Exception:
                         return None
 
                 latest = max(
-                    (
-                        v
-                        for v in (get_version(i) for i in range(winreg.QueryInfoKey(hkey)[0]))
-                        if v is not None
-                    )
+                    (v for v in (get_version(i)
+                                 for i in range(winreg.QueryInfoKey(hkey)[0]))
+                     if v is not None)
                 )
 
-                with winreg.OpenKeyEx(hkey,f'{latest}') as subkey:
+                with winreg.OpenKeyEx(hkey, f'{latest}') as subkey:
                     r_home = winreg.QueryValueEx(subkey, "InstallPath")[0]
 
                 # check for an earlier version

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import subprocess
 import tempfile
 import warnings
 
-from setuptools import setup, Extension
+from setuptools import setup, Extension, dist
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
@@ -110,6 +110,7 @@ def get_r_c_extension_status():
                                     library_dirs=c_ext.library_dirs)
     return status
 
+dist.Distribution().fetch_build_eggs(["packaging;platform_system=='Windows'"])
 
 cffi_mode = situation.get_cffi_mode()
 c_extension_status = get_r_c_extension_status()

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,11 @@ def get_r_c_extension_status():
                                     library_dirs=c_ext.library_dirs)
     return status
 
+# TODO: The following line is required because setup.py tries to figure out
+# requirements before setuptools's own machinery to ensure requirements starts,
+# even if the named argument `setup_requires` is added to setup().
+# There should be a better way to do this than side download/install a package
+# at import time. This is limited to Windows.
 dist.Distribution().fetch_build_eggs(["packaging;platform_system=='Windows'"])
 
 cffi_mode = situation.get_cffi_mode()


### PR DESCRIPTION
This is PR is addresses the issue with Windows R install path detection [#875  #885]

As I described in #885, subkeys must be searched newer R. For example, 

```
HKEY_LOCAL_MACHINE\SOFTWARE\R-core\R\4.2.0\InstallPath
```

There may be multiple R versions installed on a PC, and the PR loads the newest version using the `packaging` package (which allows easy comparison of version strings). This dependency has been added to `requirements.txt` as well as in `setup.py`. The latter requires it to be manually loaded (packages listed in the `setup_requires` seem not loaded before the `bdist_wheel` command.
