### PR TITLE
POSIXct fixes

### DIFF
--- a/rpy2/robjects/vectors.py
+++ b/rpy2/robjects/vectors.py
@@ -16,8 +16,7 @@ import time
 import pytz
 import tzlocal
 from datetime import date, datetime, timedelta, timezone
-from time import struct_time, mktime, tzname
-from operator import attrgetter
+from time import struct_time, mktime
 import typing
 import warnings
 
@@ -944,7 +943,7 @@ class POSIXct(POSIXt, FloatVector):
                 )
 
         if tz_info is None:
-            tz_info = tzname[0]
+            tz_info = default_timezone.zone if default_timezone else ''
         # We could use R's as.POSIXct instead of ISOdatetime
         # since as.POSIXct is used by it anyway, but the overall
         # interface for dates and conversion between formats
@@ -964,7 +963,7 @@ class POSIXct(POSIXt, FloatVector):
                     IntVector([x.tm_hour for x in seq]),
                     IntVector([x.tm_min for x in seq]),
                     IntVector([x.tm_sec for x in seq])]
-        return POSIXct._sexp_from_seq(seq, lambda elt: time.tzname[0], f)
+        return POSIXct._sexp_from_seq(seq, lambda elt: elt.tm_zone, f)
 
     @staticmethod
     def sexp_from_datetime(seq):
@@ -978,7 +977,10 @@ class POSIXct(POSIXt, FloatVector):
                     IntVector([x.minute for x in seq]),
                     IntVector([x.second for x in seq])]
 
-        return POSIXct._sexp_from_seq(seq, attrgetter('tzinfo'), f)
+        def get_tz(elt):
+            return elt.tzinfo.zone if elt.tzinfo else None
+
+        return POSIXct._sexp_from_seq(seq, get_tz, f)
 
     @staticmethod
     def isrinstance(obj) -> bool:

--- a/rpy2/tests/robjects/test_vector_datetime.py
+++ b/rpy2/tests/robjects/test_vector_datetime.py
@@ -58,7 +58,8 @@ def test_POSIXct_from_invalidobject():
 def default_timezone_mocker(request):
     import rpy2.robjects.vectors
     zone = request.param
-    rpy2.robjects.vectors.default_timezone = pytz.timezone(zone)
+    if zone:
+        rpy2.robjects.vectors.default_timezone = pytz.timezone(zone)
     yield zone
     rpy2.robjects.vectors.default_timezone = None
 

--- a/rpy2/tests/robjects/test_vector_datetime.py
+++ b/rpy2/tests/robjects/test_vector_datetime.py
@@ -68,9 +68,7 @@ def default_timezone_mocker(request):
     ([time.struct_time(_dateval_tuple),
       time.struct_time(_dateval_tuple)],
      [datetime.datetime(*_dateval_tuple[:-2]),
-      datetime.datetime(*_dateval_tuple[:-2])],
-     [pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2])),
-      pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2]))])
+      datetime.datetime(*_dateval_tuple[:-2])])
 )
 def test_POSIXct_from_python_times(x, default_timezone_mocker):
     res = robjects.POSIXct(x)

--- a/rpy2/tests/robjects/test_vector_datetime.py
+++ b/rpy2/tests/robjects/test_vector_datetime.py
@@ -54,8 +54,8 @@ def test_POSIXct_from_invalidobject():
         robjects.POSIXct(x)
 
 
-@pytest.fixture
-def default_timezone_mocker(scope='module', params=_zones):
+@pytest.fixture(scope='module', params=_zones)
+def default_timezone_mocker(request):
     import rpy2.robjects.vectors
     zone = request.param
     rpy2.robjects.vectors.default_timezone = pytz.timezone(zone)
@@ -76,8 +76,17 @@ def test_POSIXct_from_python_times(x, default_timezone_mocker):
     res = robjects.POSIXct(x)
     assert list(res.slots['class']) == ['POSIXct', 'POSIXt']
     assert len(res) == 2
-    a = request.getfixturevalue(a)
     zone = default_timezone_mocker
+    assert res.slots['tzone'][0] == (zone if zone else '')
+
+
+def test_POSIXct_from_python_pytz_timezone(default_timezone_mocker):
+    zone = default_timezone_mocker
+    x = [pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2])),
+         pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2]))])
+    res = robjects.POSIXct(x)
+    assert list(res.slots['class']) == ['POSIXct', 'POSIXt']
+    assert len(res) == 2
     assert res.slots['tzone'][0] == (zone if zone else '')
 
 

--- a/rpy2/tests/robjects/test_vector_datetime.py
+++ b/rpy2/tests/robjects/test_vector_datetime.py
@@ -131,12 +131,21 @@ def testPOSIXct_iter_localized_datetime():
 
 
 def test_POSIXct_datetime_from_timestamp():
-    tzone = robjects.vectors.get_timezone()
-    dt = [datetime.datetime(1900, 1, 1),
-          datetime.datetime(1970, 1, 1), 
-          datetime.datetime(2000, 1, 1)]
-    dt = [x.replace(tzinfo=tzone) for x in dt]
-    ts = [x.timestamp() for x in dt]
-    res = [robjects.POSIXct._datetime_from_timestamp(x, tzone) for x in ts]
-    for expected, obtained in zip(dt, res):
-        assert expected == obtained
+
+    try:
+        for zone in _zones:
+            if not zone:
+                continue
+            robjects.vectors.default_timezone = pytz.timezone(zone)
+
+            tzone = robjects.vectors.get_timezone()
+            dt = [datetime.datetime(1900, 1, 1),
+                  datetime.datetime(1970, 1, 1),
+                  datetime.datetime(2000, 1, 1)]
+            dt = [tzone.localize(x) for x in dt]
+            ts = [x.timestamp() for x in dt]
+            res = [robjects.POSIXct._datetime_from_timestamp(x, tzone) for x in ts]
+            for expected, obtained in zip(dt, res):
+                assert expected == obtained
+    finally:
+        robjects.vectors.default_timezone = None

--- a/rpy2/tests/robjects/test_vector_datetime.py
+++ b/rpy2/tests/robjects/test_vector_datetime.py
@@ -57,7 +57,8 @@ def test_POSIXct_from_invalidobject():
 @pytest.fixture
 def default_timezone_mocker(scope='module', params=_zones):
     import rpy2.robjects.vectors
-    rpy2.robjects.vectors.default_timezone = pytz.timezone(request.param)
+    zone = request.param
+    rpy2.robjects.vectors.default_timezone = pytz.timezone(zone)
     yield zone
     rpy2.robjects.vectors.default_timezone = None
 

--- a/rpy2/tests/robjects/test_vector_datetime.py
+++ b/rpy2/tests/robjects/test_vector_datetime.py
@@ -83,7 +83,7 @@ def test_POSIXct_from_python_times(x, default_timezone_mocker):
 def test_POSIXct_from_python_pytz_timezone(default_timezone_mocker):
     zone = default_timezone_mocker
     x = [pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2])),
-         pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2]))])
+         pytz.timezone(zone).localize(datetime.datetime(*_dateval_tuple[:-2]))]
     res = robjects.POSIXct(x)
     assert list(res.slots['class']) == ['POSIXct', 'POSIXt']
     assert len(res) == 2


### PR DESCRIPTION
This PR adds some tests for converting to `POSIXct` objects with timezones, then makes small changes to the code to get them passing.