### PR TITLE
Change rpy2[numpy] dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ if __name__ == '__main__':
 
     extras_require = {
         'test': ['pytest'],
-        'numpy': ['pandas'],
+        'numpy': ['numpy'],
         'pandas': ['numpy', 'pandas'],
         'setup': ['setuptools']
     }


### PR DESCRIPTION
In `setup.py` at line 209 there is:
```python
'numpy': ['pandas'],
```

It should be `'numpy': ['numpy'],`, isn't it?