### PR TITLE
Fixes issue #947

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+Release 3.5.5
+=============
+
+Bugs fixed
+----------
+
+- :class:`rpy2.rlike.container.TaggedList` objects were triggering an error when unpickled (issue #947).
+
+
 Release 3.5.4
 =============
 

--- a/rpy2/rlike/container.py
+++ b/rpy2/rlike/container.py
@@ -143,6 +143,7 @@ class TaggedList(list):
     """
 
     __tags: List[Optional[str]]
+    __tags = list()
 
     def __init__(self, seq, tags=None):
         super(TaggedList, self).__init__(seq)

--- a/rpy2/rlike/container.py
+++ b/rpy2/rlike/container.py
@@ -143,7 +143,6 @@ class TaggedList(list):
     """
 
     __tags: List[Optional[str]]
-    __tags = list()
 
     def __init__(self, seq, tags=None):
         super(TaggedList, self).__init__(seq)
@@ -187,6 +186,9 @@ class TaggedList(list):
         restags = self.__tags__ * y.__tags__
         resitems = super(TaggedList, self).__mul__(y)
         return type(self)(tuple(resitems), tags=restags)
+
+    def __reduce__(self):
+        return super(TaggedList, self).__reduce__()
 
     @staticmethod
     def from_items(tagval):

--- a/rpy2/tests/rlike/test_container.py
+++ b/rpy2/tests/rlike/test_container.py
@@ -1,4 +1,5 @@
 import pytest
+import pickle
 import rpy2.rlike.container as rlc
 
 
@@ -263,3 +264,13 @@ class TestTaggedList(object):
         tl = rlc.TaggedList.from_items({'a':1, 'b':2, 'c':3})
         assert set(tl.tags) == set(('a', 'b', 'c'))
         assert set(tuple(tl)) == set((1, 2, 3))
+
+    def test_pickle(self):
+        tl = rlc.TaggedList.from_items([1, 2, 3])
+        tl_pickled = pickle.dumps(tl)
+        tl_unpickled = pickle.loads(tl_pickled)
+        assert tuple(tl) == tuple(tl_unpickled)
+        assert tuple(tl.itertags()) == tuple(tl_unpickled.itertags())
+
+        
+        

--- a/rpy2/tests/rlike/test_container.py
+++ b/rpy2/tests/rlike/test_container.py
@@ -271,6 +271,3 @@ class TestTaggedList(object):
         tl_unpickled = pickle.loads(tl_pickled)
         assert tuple(tl) == tuple(tl_unpickled)
         assert tuple(tl.itertags()) == tuple(tl_unpickled.itertags())
-
-        
-        

--- a/rpy2/tests/rlike/test_container.py
+++ b/rpy2/tests/rlike/test_container.py
@@ -266,7 +266,7 @@ class TestTaggedList(object):
         assert set(tuple(tl)) == set((1, 2, 3))
 
     def test_pickle(self):
-        tl = rlc.TaggedList.from_items([1, 2, 3])
+        tl = rlc.TaggedList([1, 2, 3])
         tl_pickled = pickle.dumps(tl)
         tl_unpickled = pickle.loads(tl_pickled)
         assert tuple(tl) == tuple(tl_unpickled)


### PR DESCRIPTION
This PR adds a line to initiate `__tags` outside a method so that pickle can pick it up while dumping