### PR TITLE
Fallback to print() when show() fails.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,9 @@ Changes
 
 - :meth:`rpy2.robjects.help.Page.iteritems` is deprecated. Use the method `items()` instead.
 
+- Calling :func:`str` on rpy2 objects that are proxies of R objects is now
+  using R's `print()` whenever R's `show()` results in an error (issue #908).
+
 
 Release 3.5.4
 =============

--- a/rpy2/robjects/robject.py
+++ b/rpy2/robjects/robject.py
@@ -113,6 +113,12 @@ class RObjectMixin(abc.ABC):
                                        'consolewrite_print', s.append)):
             try:
                 self.__show(self)
+                # There can be situation where an invalid call to R`s
+                # show is made. Possibly some form of signature overriding
+                # that goes through in R through dispatch (although it
+                # should not?). In that case this is an problem upstream
+                # and this try/except is a workaround until it gets fixed.
+                # (issue #908).
             except rpy2.rinterface.embedded.RRuntimeError as rre:
                 warnings.warn(f'Invalid call to "show()" in R: {rre}')
                 self.__print(self)

--- a/rpy2/robjects/robject.py
+++ b/rpy2/robjects/robject.py
@@ -1,6 +1,7 @@
 import abc
 import os
 import typing
+import warnings
 import weakref
 import rpy2.rinterface
 import rpy2.rinterface_lib.callbacks
@@ -90,6 +91,7 @@ class RObjectMixin(abc.ABC):
     __readlines = rpy2.rinterface.baseenv.find("readLines")
     __unlink = rpy2.rinterface.baseenv.find("unlink")
     __show = _get_exported_value('methods', 'show')
+    __print = _get_exported_value('base', 'print')
 
     __slots = None
 
@@ -109,7 +111,11 @@ class RObjectMixin(abc.ABC):
         with (rpy2.rinterface_lib
               .callbacks.obj_in_module(rpy2.rinterface_lib.callbacks,
                                        'consolewrite_print', s.append)):
-            self.__show(self)
+            try:
+                self.__show(self)
+            except rpy2.rinterface.embedded.RRuntimeError as rre:
+                warnings.warn(f'Invalid call to "show()" in R: {rre}')
+                self.__print(self)
         s = str.join('', s)
         return s
 


### PR DESCRIPTION
(issue #908)