### PR TITLE
Fix fallback to string vector when pandas series of type 'object'.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ Bugs fixed
 
 - :class:`rpy2.rlike.container.TaggedList` objects were triggering an error when unpickled (issue #947).
 
+- Converting :class:`pandas.Series` of type `"object"` with a fallback
+  to R strings no longer fails with an error (issue #916).
+
 Changes
 -------
 

--- a/rpy2/robjects/pandas2ri.py
+++ b/rpy2/robjects/pandas2ri.py
@@ -139,6 +139,7 @@ _PANDASTYPE2RPY2 = {
         populate_func=_bool_populate_r_vector
     ),
     None: BoolVector,
+    bool: BoolVector,
     str: functools.partial(
         StrVector.from_iterable,
         populate_func=_str_populate_r_vector

--- a/rpy2/robjects/pandas2ri.py
+++ b/rpy2/robjects/pandas2ri.py
@@ -61,7 +61,9 @@ def py2rpy_pandasdataframe(obj):
                           'the column "%s". Fall back to string conversion. '
                           'The error is: %s'
                           % (name, str(e)))
-            od[name] = StrVector(values)
+            od[name] = conversion.converter_ctx.get().py2rpy(
+                values.astype('string')
+            )
 
     return DataFrame(od)
 

--- a/rpy2/tests/robjects/test_pandas_conversions.py
+++ b/rpy2/tests/robjects/test_pandas_conversions.py
@@ -191,12 +191,16 @@ class TestPandasConversions(object):
     @pytest.mark.parametrize(
         'dtype', [bool, pandas.BooleanDtype() if has_pandas else None]
     )
-    def test_series_obj_bool(self, data, dtype):
-        Series = pandas.core.series.Series
-        s = Series(data, index=['a', 'b', 'c'], dtype=dtype)
+    @pytest.mark.parametrize(
+        'constructor,wrapcheck',
+        [(pandas.core.series.Series, lambda x: x),
+         (pandas.DataFrame, lambda x: x[0])]
+    )
+    def test_series_obj_bool(self, data, dtype, constructor, wrapcheck):
+        s = constructor(data, index=['a', 'b', 'c'], dtype=dtype)
         with localconverter(default_converter + rpyp.converter) as cv:
             rp_s = robjects.conversion.converter_ctx.get().py2rpy(s)
-        assert isinstance(rp_s, rinterface.BoolSexpVector)
+        assert isinstance(wrapcheck(rp_s), rinterface.BoolSexpVector)
 
 
     @pytest.mark.parametrize(

--- a/rpy2/tests/robjects/test_pandas_conversions.py
+++ b/rpy2/tests/robjects/test_pandas_conversions.py
@@ -183,13 +183,15 @@ class TestPandasConversions(object):
             with pytest.raises(ValueError):
                 rp_s = robjects.conversion.converter_ctx.get().py2rpy(s)
 
+    @pytest.mark.skipif(not has_pandas,
+                        reason='pandas must be installed.')
     @pytest.mark.parametrize(
         'data',
         ([True, False, True],
          [True, False, None])
     )
     @pytest.mark.parametrize(
-        'dtype', [bool, pandas.BooleanDtype() if has_pandas else None]
+        'dtype', [bool, pandas.BooleanDtype()]
     )
     @pytest.mark.parametrize(
         'constructor,wrapcheck',

--- a/rpy2/tests/robjects/test_pandas_conversions.py
+++ b/rpy2/tests/robjects/test_pandas_conversions.py
@@ -191,11 +191,11 @@ class TestPandasConversions(object):
          [True, False, None])
     )
     @pytest.mark.parametrize(
-        'dtype', [bool, pandas.BooleanDtype()]
+        'dtype', [bool, pandas.BooleanDtype() if has_pandas else None]
     )
     @pytest.mark.parametrize(
         'constructor,wrapcheck',
-        [(pandas.core.series.Series, lambda x: x),
+        [(pandas.Series, lambda x: x),
          (pandas.DataFrame, lambda x: x[0])]
     )
     def test_series_obj_bool(self, data, dtype, constructor, wrapcheck):


### PR DESCRIPTION
This will fix the error part of issue #916. Type guessing can be the source of impredictability. Consistent conversion objects->R strings is predictable. Explicit conversion to the desired type can be done in the Python upstream.