### PR TITLE
Avoid assuming that all R function defaults are Vector objects during signature mapping.

### DIFF
--- a/rpy2/rlike/container.py
+++ b/rpy2/rlike/container.py
@@ -40,10 +40,10 @@ class OrdDict(dict):
         return cp
 
     def __cmp__(self, o):
-        raise(NotImplementedError("Not yet implemented."))
+        return NotImplemented
 
     def __eq__(self, o):
-        raise(NotImplementedError("Not yet implemented."))
+        return NotImplemented
 
     def __getitem__(self, key: str):
         if key is None:
@@ -64,7 +64,7 @@ class OrdDict(dict):
         return len(self.__l)
 
     def __ne__(self, o):
-        raise(NotImplementedError('Not yet implemented.'))
+        return NotImplemented
 
     def __repr__(self) -> str:
         s = ['o{', ]
@@ -74,7 +74,7 @@ class OrdDict(dict):
         return ''.join(s)
 
     def __reversed__(self):
-        raise(NotImplementedError("Not yet implemented."))
+        raise NotImplementedError("Not yet implemented.")
 
     def __setitem__(self, key: Optional[str], value: Any):
         """ Replace the element if the key is known,

--- a/rpy2/robjects/functions.py
+++ b/rpy2/robjects/functions.py
@@ -11,6 +11,7 @@ import rpy2.rinterface as rinterface
 import rpy2.rinterface_lib.sexp
 from rpy2.robjects import help
 from rpy2.robjects import conversion
+from rpy2.robjects.vectors import Vector
 
 from rpy2.robjects.packages_utils import (default_symbol_r2python,
                                           default_symbol_resolve,
@@ -339,11 +340,14 @@ def map_signature(
                 r_ellipsis = i
                 warnings.warn('The R ellispsis is not yet well supported.')
             transl_name = rev_prm_transl.get(name)
-            default_orig = default_orig[0]
-            if map_default and not rinterface.MissingArg.rsame(default_orig):
-                default_mapped = map_default(default_orig)
+            if isinstance(default_orig, Vector):
+                default_orig = default_orig[0]
+                if map_default and not rinterface.MissingArg.rsame(default_orig):
+                    default_mapped = map_default(default_orig)
+                else:
+                    default_mapped = inspect.Parameter.empty
             else:
-                default_mapped = inspect.Parameter.empty
+                default_mapped = default_orig
             prm = inspect.Parameter(
                 transl_name if transl_name else name,
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/rpy2/tests/rlike/test_container.py
+++ b/rpy2/tests/rlike/test_container.py
@@ -15,16 +15,17 @@ class TestOrdDict(object):
         with pytest.raises(TypeError):
             rlc.OrdDict({})
 
-    @pytest.mark.parametrize('methodname,args',
-                             (('__cmp__', [None]),
-                              ('__eq__', [None]),
-                              ('__ne__', [None]),
-                              ('__reversed__', []),
-                              ('sort', [])))
-    def test_notimplemented(self, methodname, args):
+    def test_notimplemented_operators(self):
         nl = rlc.OrdDict()
+        nl2 = rlc.OrdDict()
+        assert nl == nl  # equivalent to `nl is nl`
+        assert nl != nl2  # equivalent to `nl is not nl2`
+        with pytest.raises(TypeError):
+            nl > nl2
         with pytest.raises(NotImplementedError):
-            getattr(nl, methodname)(*args)
+            reversed(nl)
+        with pytest.raises(NotImplementedError):
+            nl.sort()
 
     def test_repr(self):
         x = (('a', 123), ('b', 456), ('c', 789))
@@ -48,7 +49,7 @@ class TestOrdDict(object):
 
     def test_getsetitem(self):
         x = rlc.OrdDict()
-        
+
         x['a'] = 1
         assert len(x) == 1
         assert x['a'] == 1
@@ -68,7 +69,7 @@ class TestOrdDict(object):
         assert x.get('a') == 1
         assert x.get('b') is None
         assert x.get('b', 2) == 2
-        
+
     def test_keys(self):
         x = rlc.OrdDict()
         word = 'abcdef'
@@ -79,7 +80,7 @@ class TestOrdDict(object):
 
     def test_getsetitemwithnone(self):
         x = rlc.OrdDict()
-        
+
         x['a'] = 1
         x[None] = 2
         assert len(x) == 2
@@ -89,7 +90,7 @@ class TestOrdDict(object):
         assert x['b'] == 5
         assert x.index('a') == 0
         assert x.index('b') == 2
-        
+
     def test_reverse(self):
         x = rlc.OrdDict()
         x['a'] = 3
@@ -116,14 +117,14 @@ class TestOrdDict(object):
 class TestTaggedList(object):
 
     def test__add__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl = tl + tl
         assert len(tl) == 6
         assert tl.tags == ('a', 'b', 'c', 'a', 'b', 'c')
         assert tuple(tl) == (1,2,3,1,2,3)
 
     def test__delitem__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         assert len(tl) == 3
         del tl[1]
         assert len(tl) == 2
@@ -131,14 +132,14 @@ class TestTaggedList(object):
         assert tuple(tl) == (1, 3)
 
     def test__delslice__(self):
-        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))        
+        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))
         del tl[1:3]
         assert len(tl) == 2
         assert tl.tags == ('a', 'd')
         assert tuple(tl) == (1, 4)
 
     def test__iadd__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl += tl
         assert len(tl) == 6
         assert tl.tags == ('a', 'b', 'c', 'a', 'b', 'c')
@@ -152,19 +153,19 @@ class TestTaggedList(object):
         assert tuple(tl) == (1,2,1,2,1,2)
 
     def test__init__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         with pytest.raises(ValueError):
             rlc.TaggedList((1,2,3), tags = ('b', 'c'))
 
     def test__setslice__(self):
-        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))        
+        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))
         tl[1:3] = [5, 6]
         assert len(tl) == 4
         assert tl.tags == ('a', 'b', 'c', 'd')
         assert tuple(tl) == (1, 5, 6, 4)
 
     def test_append(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         assert len(tl) == 3
         tl.append(4, tag='a')
         assert len(tl) == 4
@@ -172,19 +173,19 @@ class TestTaggedList(object):
         assert tl.tags == ('a', 'b', 'c', 'a')
 
     def test_extend(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl.extend([4, 5])
         assert tuple(tl.itertags()) == ('a', 'b', 'c', None, None)
         assert tuple(tl) == (1, 2, 3, 4, 5)
 
     def test_insert(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl.insert(1, 4, tag = 'd')
         assert tuple(tl.itertags()) == ('a', 'd', 'b', 'c')
         assert tuple(tl) == (1, 4, 2, 3)
 
     def test_items(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         assert tuple(tl.items()) == (('a', 1), ('b', 2), ('c', 3))
 
     def test_iterontag(self):


### PR DESCRIPTION
Hi @lgautier ,

One of the issues we faced when migrating to rpy2 3.5 was that the function signatures assumed that our functions had default values that were simple vectors. Some of our methods had default values that were ordered mappings, which caused the signature mapping to fail.

This patch fixes this issue (feel free to push changes directly to this branch to get things into a state you would be willing to merge).