### PR TITLE
Fix pickling of `OrdDict`.

### DIFF
--- a/rpy2/rlike/container.py
+++ b/rpy2/rlike/container.py
@@ -39,6 +39,17 @@ class OrdDict(dict):
         cp = OrdDict(c=tuple(self.items()))
         return cp
 
+    def __reduce__(self):
+        # We need to override the special-cased dict unpickling process in order
+        # to retain the attributes the `__l` attribute.
+        return (
+            self.__class__,  # callable
+            (),  # arguments to constructor
+            {'_OrdDict__l': self.__l},  # state
+            None,  # list items
+            iter(self.items()),  # dict items
+        )
+
     def __cmp__(self, o):
         raise(NotImplementedError("Not yet implemented."))
 

--- a/rpy2/tests/rlike/test_container.py
+++ b/rpy2/tests/rlike/test_container.py
@@ -1,5 +1,7 @@
 import pytest
 import pickle
+from io import BytesIO
+
 import rpy2.rlike.container as rlc
 
 
@@ -48,7 +50,7 @@ class TestOrdDict(object):
 
     def test_getsetitem(self):
         x = rlc.OrdDict()
-        
+
         x['a'] = 1
         assert len(x) == 1
         assert x['a'] == 1
@@ -68,7 +70,7 @@ class TestOrdDict(object):
         assert x.get('a') == 1
         assert x.get('b') is None
         assert x.get('b', 2) == 2
-        
+
     def test_keys(self):
         x = rlc.OrdDict()
         word = 'abcdef'
@@ -79,7 +81,7 @@ class TestOrdDict(object):
 
     def test_getsetitemwithnone(self):
         x = rlc.OrdDict()
-        
+
         x['a'] = 1
         x[None] = 2
         assert len(x) == 2
@@ -89,7 +91,7 @@ class TestOrdDict(object):
         assert x['b'] == 5
         assert x.index('a') == 0
         assert x.index('b') == 2
-        
+
     def test_reverse(self):
         x = rlc.OrdDict()
         x['a'] = 3
@@ -112,18 +114,28 @@ class TestOrdDict(object):
             assert ki[0] ==  ko[0]
             assert ki[1] == ko[1]
 
+    def test_pickling(self):
+        f = BytesIO()
+        pickle.dump(rlc.OrdDict([('a', 1), ('b', 2)]), f)
+        f.seek(0)
+        od = pickle.load(f)
+        assert od['a'] == 1
+        assert od.index('a') == 0
+        assert od['b'] == 2
+        assert od.index('b') == 1
+
 
 class TestTaggedList(object):
 
     def test__add__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl = tl + tl
         assert len(tl) == 6
         assert tl.tags == ('a', 'b', 'c', 'a', 'b', 'c')
         assert tuple(tl) == (1,2,3,1,2,3)
 
     def test__delitem__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         assert len(tl) == 3
         del tl[1]
         assert len(tl) == 2
@@ -131,14 +143,14 @@ class TestTaggedList(object):
         assert tuple(tl) == (1, 3)
 
     def test__delslice__(self):
-        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))        
+        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))
         del tl[1:3]
         assert len(tl) == 2
         assert tl.tags == ('a', 'd')
         assert tuple(tl) == (1, 4)
 
     def test__iadd__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl += tl
         assert len(tl) == 6
         assert tl.tags == ('a', 'b', 'c', 'a', 'b', 'c')
@@ -152,19 +164,19 @@ class TestTaggedList(object):
         assert tuple(tl) == (1,2,1,2,1,2)
 
     def test__init__(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         with pytest.raises(ValueError):
             rlc.TaggedList((1,2,3), tags = ('b', 'c'))
 
     def test__setslice__(self):
-        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))        
+        tl = rlc.TaggedList((1,2,3,4), tags=('a', 'b', 'c', 'd'))
         tl[1:3] = [5, 6]
         assert len(tl) == 4
         assert tl.tags == ('a', 'b', 'c', 'd')
         assert tuple(tl) == (1, 5, 6, 4)
 
     def test_append(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         assert len(tl) == 3
         tl.append(4, tag='a')
         assert len(tl) == 4
@@ -172,19 +184,19 @@ class TestTaggedList(object):
         assert tl.tags == ('a', 'b', 'c', 'a')
 
     def test_extend(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl.extend([4, 5])
         assert tuple(tl.itertags()) == ('a', 'b', 'c', None, None)
         assert tuple(tl) == (1, 2, 3, 4, 5)
 
     def test_insert(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         tl.insert(1, 4, tag = 'd')
         assert tuple(tl.itertags()) == ('a', 'd', 'b', 'c')
         assert tuple(tl) == (1, 4, 2, 3)
 
     def test_items(self):
-        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))        
+        tl = rlc.TaggedList((1,2,3), tags=('a', 'b', 'c'))
         assert tuple(tl.items()) == (('a', 1), ('b', 2), ('c', 3))
 
     def test_iterontag(self):


### PR DESCRIPTION
Hi again @lgautier!

We use `rpy2` in the context of multiprocessing, where communication between processes is done using pickled objects. As such, when migrating from `rpy2` 3.4 to 3.5, we were seeing unpickling errors. This patch solves this problem (and combined with my other patch, makes it possible for us to move to `rpy2` 3.5+).

You can see this breaking in the current version using:

```
import pickle
from io import BytesIO
from rpy2.rlike.container import OrdDict

f = BytesIO()
pickle.dump(OrdDict([('a', 1), ('b', 2)]), f)
f.seek(0)
pickle.load(f)
```