### PR TITLE
Default for ContextVar with conversion rules raising errors.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,16 @@ Bugs fixed
   C99-compatible or requires to be specified C99 compatibility
   (issue #963).
 
+Changes
+-------
+
+- The default for the :class:`contextvars.ContextVar` holding
+  conversion rules (:obj:`rpy2.robjects.conversion.converter`)
+  is now a dummy converter raising errors about missing
+  conversion rules. This behavior helps with troubleshooting
+  Python code using multithreading without fetching the context
+  (see issue #965).
+
 
 Release 3.5.6
 =============

--- a/rpy2/robjects/conversion.py
+++ b/rpy2/robjects/conversion.py
@@ -351,8 +351,30 @@ class ConversionContext(object):
 
 localconverter = ConversionContext
 
+
+def _raise_missingconverter(obj):
+    _missingconverter_msg = """
+    Conversion rules for `rpy2.robjects` appear to be missing. Those
+    rules are in a Python contextvars.ContextVar. This could be caused
+    by multithreading code not passing context to the thread.
+    """
+    raise NotImplementedError(_missingconverter_msg)
+
+
+missingconverter = Converter('missing')
+
+missingconverter.rpy2py.register(
+    object,
+    _raise_missingconverter
+)
+
+missingconverter.py2rpy.register(
+    object,
+    _raise_missingconverter
+)
+
 converter_ctx = contextvars.ContextVar('converter',
-                                       default=Converter('empty'))
+                                       default=missingconverter)
 
 
 def _deprecated_converter():


### PR DESCRIPTION
The error message is meant to point users experiencing it toward the root of the issue.

(issue #965)