### PR TITLE
Make Converter objects context managers.

### DIFF
--- a/doc/notebooks/pandas.md
+++ b/doc/notebooks/pandas.md
@@ -19,8 +19,6 @@ import pandas as pd
 import rpy2.robjects as ro
 from rpy2.robjects.packages import importr 
 from rpy2.robjects import pandas2ri
-
-from rpy2.robjects.conversion import localconverter
 ```
 
 ## From `pandas` to `R`
@@ -37,8 +35,8 @@ pd_df
 R data frame converted from a `pandas` data frame:
 
 ```python
-with localconverter(ro.default_converter + pandas2ri.converter):
-  r_from_pd_df = ro.conversion.py2rpy(pd_df)
+with ro.default_converter + pandas2ri.converter:
+  r_from_pd_df = ro.conversion.get_conversion().py2rpy(pd_df)
 
 r_from_pd_df
 ```
@@ -49,7 +47,7 @@ For example, when calling the R function `base::summary`:
 ```python
 base = importr('base')
 
-with localconverter(ro.default_converter + pandas2ri.converter):
+with ro.default_converter + pandas2ri.converter:
   df_summary = base.summary(pd_df)
 print(df_summary)
 ```
@@ -80,8 +78,8 @@ r_df
 It can be converted to a pandas data frame using the same converter:
 
 ```python
-with localconverter(ro.default_converter + pandas2ri.converter):
-  pd_from_r_df = ro.conversion.rpy2py(r_df)
+with ro.default_converter + pandas2ri.converter:
+  pd_from_r_df = ro.conversion.get_conversion().rpy2py(r_df)
 
 pd_from_r_df
 ```
@@ -97,7 +95,7 @@ pd_df
 ```
 
 ```python
-with localconverter(ro.default_converter + pandas2ri.converter):
+with ro.default_converter + pandas2ri.converter:
   r_from_pd_df = ro.conversion.py2rpy(pd_df)
 
 r_from_pd_df
@@ -113,7 +111,7 @@ pd_tz_df = pd.DataFrame({
                                tz='UTC')
     })
     
-with localconverter(ro.default_converter + pandas2ri.converter):
+with ro.default_converter + pandas2ri.converter:
   r_from_pd_tz_df = ro.conversion.py2rpy(pd_tz_df)
 
 r_from_pd_tz_df

--- a/doc/numpy.rst
+++ b/doc/numpy.rst
@@ -109,13 +109,12 @@ of conversion rules to code blocks of interest easier to achieve.
    
    from rpy2.robjects import numpy2ri
    from rpy2.robjects import default_converter
-   from rpy2.robjects.conversion localconverter
 
    # Create a converter that starts with rpy2's default converter
    # to which the numpy conversion rules are added.
    np_cv_rules = default_converter + numpy2ri.converter
 
-   with localconverter(np_cv_rules) as cv:
+   with np_cv_rules:
        # Anything here and until the `with` block is exited
        # will use our numpy converter whenever objects are
        # passed to R or are returned by R while calling
@@ -128,7 +127,7 @@ An example of usage is:
 
    from rpy2.robjects.packages import importr
    stats = importr('base')
-   with localconverter(np_cv_rules) as cv:
+   with np_cv_rules:
        v_np = stats.rlogis(100, location=0, scale=1)
        # `v_np` is a numpy array
 

--- a/doc/robjects_convert.rst
+++ b/doc/robjects_convert.rst
@@ -215,7 +215,7 @@ Local conversion rules
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The conversion rules can be customized globally (See section `Customizing the conversion`)
-or through the use of local converters as context managers.
+or locally in a Python `with` block.
 
 .. note::
 
@@ -246,8 +246,7 @@ default conversion scheme:
 .. code-block:: python
 
    from rpy2.robjects import default_converter
-   from rpy2.robjects.conversion import Converter, localconverter
-   with localconverter(conversion_rules) as cv:
+   with conversion_rules:
        res = base.paste(x, collapse="-")
 
 .. note::
@@ -261,10 +260,9 @@ default conversion scheme:
    .. code-block:: python
 
       from rpy2.robjects import default_converter
-      from rpy2.robjects.conversion import localconverter
 
       def my_function(obj):
-          with localconverter(default_converter) as cv:
+          with default_converter:
               # block of code mixing Python code and calls to R functions
 	      # interacting with the objects returned by R in the Python code
 	      pass

--- a/rpy2/robjects/conversion.py
+++ b/rpy2/robjects/conversion.py
@@ -304,6 +304,15 @@ class Converter(object):
         overlay_converter(converter, result_converter)
         return result_converter
 
+    def __enter__(self):
+        self._original_converter = converter_ctx.get()
+        set_conversion(self)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        set_conversion(self._original_converter)
+        return False
+
     def __str__(self):
         res = [str(type(self))]
         for subcv in ('py2rpy', 'rpy2py'):
@@ -351,8 +360,10 @@ class ConversionContext(object):
 
 localconverter = ConversionContext
 
-converter_ctx = contextvars.ContextVar('converter',
-                                       default=Converter('empty'))
+converter_ctx: contextvars.ContextVar[Converter] = (
+    contextvars.ContextVar('converter',
+                           default=Converter('empty'))
+)
 
 
 def _deprecated_converter():


### PR DESCRIPTION
This can simplify usage and make calls to localconverter() unnecessary.