### PR TITLE
Fix segfault when calling rinternalize and R not initialized.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,10 @@ Bugs fixed
 - With the "R magic", converters in a local namespace were inadvertently
   skipped (the local namespace was not searched).
 
+- Calling :func:`rpy2.rinterface.rternalize` before the embedded R is
+  initialized was ending with a segfault. It is now raising an
+  :class:`rpy2.rinterface_lib/embedded/RNotReady` (issue #971).
+
 Changes
 -------
 

--- a/rpy2/rinterface.py
+++ b/rpy2/rinterface.py
@@ -1201,6 +1201,8 @@ def rternalize(
     :return: A wrapped R object that can be use like any other rpy2
     object.
     """
+    if not embedded.isinitialized():
+        raise embedded.RNotReadyError('The embedded R is not yet initialized.')
 
     if function is None:
         return functools.partial(rternalize, signature=signature)

--- a/rpy2/tests/rinterface/test_noinitialization.py
+++ b/rpy2/tests/rinterface/test_noinitialization.py
@@ -28,3 +28,9 @@ def test_assert_isready():
 def test_assert_environment_geitem():
     with pytest.raises(embedded.RNotReadyError):
         sexp.globalenv['x']
+
+@pytest.mark.skipif(embedded.rpy2_embeddedR_isinitialized,
+                    reason='Can only be tested before R is initialized.')
+def test_assert_rternalize():
+    with pytest.raises(embedded.RNotReadyError):
+        rinterface.rternalize(lambda x: x)


### PR DESCRIPTION
This is fixing issue #971.