### PR TITLE
Fix handling of CHARSXP added in #PR 987.

### DIFF
--- a/rpy2/robjects/numpy2ri.py
+++ b/rpy2/robjects/numpy2ri.py
@@ -32,12 +32,15 @@ _kinds = {
 
 
 _vectortypes = set(
-    (RTYPES.CHARSXP,
-     RTYPES.LGLSXP,
-     RTYPES.INTSXP,
-     RTYPES.REALSXP,
-     RTYPES.CPLXSXP,
-     RTYPES.STRSXP)
+    (
+        # TODO: CHARSXP is an fact a scalar.
+        RTYPES.CHARSXP,
+        RTYPES.LGLSXP,
+        RTYPES.INTSXP,
+        RTYPES.REALSXP,
+        RTYPES.CPLXSXP,
+        RTYPES.STRSXP
+    )
 )
 
 converter = conversion.Converter('original numpy conversion')
@@ -201,14 +204,12 @@ def rpy2py_floatvector(obj):
 
 @rpy2py.register(Sexp)
 def rpy2py_sexp(obj):
-    if (obj.typeof in _vectortypes) and (obj.typeof != RTYPES.VECSXP):
+    if obj.typeof is rinterface.RTYPES.CHARSXP:
+        res = None
+    elif (obj.typeof in _vectortypes) and (obj.typeof != RTYPES.VECSXP):
         res = numpy.array(obj)
         # Special case for R string arrays.
-        if (
-                obj.typeof is rinterface.RTYPES.CHARSXP
-                or
-                obj.typeof is rinterface.RTYPES.STRSXP
-        ):
+        if obj.typeof is rinterface.RTYPES.STRSXP:
             res[res == rinterface.NA_Character] = None
     else:
         res = ro.default_converter.rpy2py(obj)


### PR DESCRIPTION
CHARSXP objects are considered vectors by R but are in fact scalars (and only available at C-level). This fix should likely be followed by a more formal handling of C-level scalars in R.