### PR TITLE
Clear warnings originating from `formals()` called on non-function ob…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ Bugs fixed
 - Building the path to the R shared library was incorrectly
   using the output of `R CMD config LIBnn` (issue #982).
 
+- R started raising warnings when calling `formals` on `SPECIALSXP` R objects.
+  Internal functions :mod:`rpy.robjects.functions` calling `formals` no longer
+  propagate the warnings.
+
 
 Release 3.5.8
 =============

--- a/rpy2/robjects/functions.py
+++ b/rpy2/robjects/functions.py
@@ -28,9 +28,12 @@ __is_null = baseenv_ri.find('is.null')
 
 
 def _formals_fixed(func):
-    res = __formals(func)
-    if res is rpy2.rinterface_lib.sexp.NULL:
-        res = __formals(__args(func))
+    if func.typeof is rpy2.rinterface_lib.sexp.RTYPES.SPECIALSXP:
+        res = rpy2.rinterface_lib.sexp.NULL
+    else:
+        res = __formals(func)
+        if res is rpy2.rinterface_lib.sexp.NULL:
+            res = __formals(__args(func))
     return res
 
 


### PR DESCRIPTION
…jects.