### PR TITLE
Getrenvvars issue1066

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ Bugs fixed
 - Fixed notebook representation of R named arrays or vectors when
   conversion rules might interfere (issue #1047).
 
+- Multi-line in environment variables (issue #1066).
+
 
 Release 3.5.14
 ==============

--- a/rpy2/rinterface.py
+++ b/rpy2/rinterface.py
@@ -1132,7 +1132,7 @@ def _getrenvvars(
         os.path.join(r_home, 'bin', 'Rscript'),
         '-e',
         'x<-Sys.getenv();y<-as.character(x);names(y)<-names(x);'
-        'write.table(y,col.names=FALSE,quote=TRUE,sep=",")'
+        'write.csv(y)'
     )
 
     envvars = subprocess.check_output(cmd,
@@ -1141,6 +1141,8 @@ def _getrenvvars(
 
     res = []
     reader = csv.reader(row for row in envvars.split(os.linesep) if row != '')
+    # Skip column names.
+    next(reader)
     for k, v in reader:
         if (
                 (k not in baselinevars)


### PR DESCRIPTION
Use `write.csv()` to pass environment variables set by the R script to Python.

This should fix issue #1066.