### PR TITLE
Remove invalid expectation for warnings in some tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-test_minimal = ["pytest", "coverage", "pytest-cov"]
+test_minimal = ["pytest>=8", "coverage", "pytest-cov"]
 test = ["pytest", "ipython", "numpy", "pandas>=1.3.5"]
 numpy = []
 pandas = ["numpy", "pandas>=1.3.5"]

--- a/rpy2/tests/rinterface/test_callbacks.py
+++ b/rpy2/tests/rinterface/test_callbacks.py
@@ -266,8 +266,7 @@ def test_choosefile_error():
                              utils.noconsole):
         with utils.obj_in_module(callbacks, 'choosefile', f):
             with pytest.raises(rinterface.embedded.RRuntimeError):
-                with pytest.warns(rinterface.RRuntimeWarning):
-                    rinterface.baseenv["file.choose"]()
+                rinterface.baseenv["file.choose"]()
 
 
 def test_showfiles_default(capsys):

--- a/rpy2/tests/rinterface/test_environment.py
+++ b/rpy2/tests/rinterface/test_environment.py
@@ -156,8 +156,7 @@ def test_subscript_utf8():
 
 def test_subscript_missing_utf8():
     env = rinterface.baseenv['new.env']()
-    with pytest.raises(KeyError),\
-            pytest.warns(rinterface.RRuntimeWarning):
+    with pytest.raises(KeyError):
         env['呵呵']
 
 

--- a/rpy2/tests/rinterface/test_functions.py
+++ b/rpy2/tests/rinterface/test_functions.py
@@ -36,8 +36,7 @@ def test_typeof():
 def test_r_error():
     r_sum = rinterface.baseenv['sum']
     letters = rinterface.baseenv['letters']
-    with pytest.raises(rinterface.embedded.RRuntimeError),\
-            pytest.warns(rinterface.RRuntimeWarning):
+    with pytest.raises(rinterface.embedded.RRuntimeError):
         r_sum(letters)
 
 
@@ -77,8 +76,7 @@ def test_closureenv():
     assert isinstance(fun.closureenv, rinterface.SexpEnvironment)
 
     with pytest.raises(rinterface.embedded.RRuntimeError):
-        with pytest.warns(rinterface.RRuntimeWarning):
-            fun(vec)
+        fun(vec)
 
     fun.closureenv['y'] = (rinterface
                            .IntSexpVector([1, ]))
@@ -132,8 +130,7 @@ def test_call_OrdDictEnv():
 def test_error_in_call():
     r_sum = rinterface.baseenv['sum']
 
-    with pytest.raises(rinterface.embedded.RRuntimeError),\
-            pytest.warns(rinterface.RRuntimeWarning):
+    with pytest.raises(rinterface.embedded.RRuntimeError):
         r_sum(2, 'a')
 
 

--- a/rpy2/tests/robjects/test_packages.py
+++ b/rpy2/tests/robjects/test_packages.py
@@ -117,8 +117,7 @@ class TestImportr(object):
     def test_import_stats_with_libloc_with_quote(self):
         path = 'coin"coin'
 
-        with pytest.raises(robjects.packages.PackageNotInstalledError), \
-             pytest.warns(UserWarning):
+        with pytest.raises(robjects.packages.PackageNotInstalledError):
             Tmp_File = io.StringIO
             tmp_file = Tmp_File()
             try:


### PR DESCRIPTION
Upgrading to pytest 8.0 catches those invalid tests.