### PR TITLE
Fix a bug in rmagic.py

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ Bugs fixed
   clearly errors due unspecified package name or missing class
   definition in within the package namespace specified.
 
+- The display of SVG figures in jupyter notebooks is fixed.
+  the was a typo in the form of a trailing comma.
+
 
 Release 3.5.15
 ==============

--- a/rpy2/ipython/rmagic.py
+++ b/rpy2/ipython/rmagic.py
@@ -275,7 +275,7 @@ def display_figures_svg(graph_dir, isolate_svgs=True):
     # Cairo creates an SVG file every time R is called
     # -- empty ones are not published
     if os.stat(imgfile).st_size >= 1000:
-        img = IPython.display.SVG(filename=imgfile),
+        img = IPython.display.SVG(filename=imgfile)
         IPython.display.display_svg(
             img,
             metadata={'image/svg+xml': dict(isolated=True)} if isolate_svgs else {}


### PR DESCRIPTION
An ending "," in line 278 is a bug, which prevents SVG from displaying in notebook or nbconvert.