### PR TITLE
Use cffi's `onerror` callback to manage errors.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -106,6 +106,11 @@ jobs:
         use-public-rspm: true
     - name: Print R config
       run: R CMD config --all
+    - name: macos fix for lib deflate
+      if: "!startsWith(matrix.os, 'macos')"
+      run: |
+        curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
+        tar xz libdeflate-1.23-darwin.20-arm64.tar.xz -C /
     - name: Set env commands (POSIX)
       if: "!startsWith(matrix.os, 'windows')"
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -104,6 +104,8 @@ jobs:
       with:
         r-version: ${{ matrix.r-version }}
         use-public-rspm: true
+    - name: Print R config
+      run: R CMD config --all
     - name: Set env commands (POSIX)
       if: "!startsWith(matrix.os, 'windows')"
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
-        r-version: [release]
+        r-version: [release, "4.5"]
         os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         exclude:
           - os: macos-14
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        r-version: [release]
+        r-version: [release, "4.5"]
         os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         package: [{dir: ".", name: "rpy2"}, {dir: "rpy2-robjects", name: "rpy2-robjects"}]
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -106,11 +106,6 @@ jobs:
         use-public-rspm: true
     - name: Print R config
       run: R CMD config --all
-    - name: macos fix for lib deflate
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
-        tar xz libdeflate-1.23-darwin.20-arm64.tar.xz -C /
     - name: Set env commands (POSIX)
       if: "!startsWith(matrix.os, 'windows')"
       run: |
@@ -126,7 +121,8 @@ jobs:
       if: startsWith(matrix.os, 'macos') && contains(fromJson('["3.8", "3.9", "3.12", "3.13"]'), matrix.python-version)
       shell: bash
       run: |
-        brew install libdeflate
+        curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
+        tar xz libdeflate-1.23-darwin.20-arm64.tar.xz -C /
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Print R config
       run: R CMD config --all
     - name: macos fix for lib deflate
-      if: "!startsWith(matrix.os, 'macos')"
+      if: startsWith(matrix.os, 'macos')
       run: |
         curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
         tar xz libdeflate-1.23-darwin.20-arm64.tar.xz -C /

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -122,7 +122,7 @@ jobs:
       shell: bash
       run: |
         curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
-        tar xz libdeflate-1.23-darwin.20-arm64.tar.xz -C /
+        tar xJf libdeflate-1.23-darwin.20-arm64.tar.xz -C /
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
-        r-version: [release, "devel"]
+        r-version: [release]
         os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         exclude:
           - os: macos-14
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        r-version: [release, "devel"]
+        r-version: [release]
         os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         package: [{dir: ".", name: "rpy2"}, {dir: "rpy2-robjects", name: "rpy2-robjects"}]
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -104,7 +104,8 @@ jobs:
       with:
         r-version: ${{ matrix.r-version }}
         use-public-rspm: true
-    - name: Print R config
+    - name: Print R config (POSIX-only)
+      if: "!startsWith(matrix.os, 'windows')"
       run: R CMD config --all
     - name: Set env commands (POSIX)
       if: "!startsWith(matrix.os, 'windows')"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -87,7 +87,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
         r-version: [release]
-        os: ["windows-latest", ubuntu-latest, macos-14]
+        os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         exclude:
           - os: macos-14
             python-version: 3.9
@@ -144,7 +144,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         r-version: [release]
-        os: ["windows-latest", ubuntu-latest, macos-14]
+        os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         package: [{dir: ".", name: "rpy2"}, {dir: "rpy2-robjects", name: "rpy2-robjects"}]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -119,7 +119,7 @@ jobs:
         echo "VENV_ACTIVATE=pyenv_base\Scripts\activate" >> $GITHUB_ENV
         echo "R_LIBRARY=''" >> $GITHUB_ENV
     - name: Patch GHA issue with macos - Missing C library
-      if: startsWith(matrix.os, 'macos') && contains(fromJson('["3.8", "3.9", "3.12", "3.13"]'), matrix.python-version)
+      if: startsWith(matrix.os, 'macos')
       shell: bash
       run: |
         curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
-        r-version: [release, "4.5"]
+        r-version: [release, "devel"]
         os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         exclude:
           - os: macos-14
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        r-version: [release, "4.5"]
+        r-version: [release, "devel"]
         os: ["windows-latest", ubuntu-latest, macos-14, macos-15]
         package: [{dir: ".", name: "rpy2"}, {dir: "rpy2-robjects", name: "rpy2-robjects"}]
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -116,7 +116,7 @@ jobs:
         echo "VENV_ACTIVATE=pyenv_base\Scripts\activate" >> $GITHUB_ENV
         echo "R_LIBRARY=''" >> $GITHUB_ENV
     - name: Patch GHA issue with macos - Missing C library
-      if: startsWith(matrix.os, 'macos') && (matrix.python-version == "3.13")
+      if: startsWith(matrix.os, 'macos') && contains(fromJson('["3.8", "3.9", "3.12", "3.13"]'), matrix.python-version)
       shell: bash
       run: |
         brew install libdeflate

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -115,6 +115,11 @@ jobs:
       run: |
         echo "VENV_ACTIVATE=pyenv_base\Scripts\activate" >> $GITHUB_ENV
         echo "R_LIBRARY=''" >> $GITHUB_ENV
+    - name: Patch GHA issue with macos - Missing C library
+      if: startsWith(matrix.os, 'macos') && (matrix.python-version == "3.13")
+      shell: bash
+      run: |
+        brew install libdeflate
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -123,7 +123,7 @@ jobs:
       shell: bash
       run: |
         curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
-        tar xJf libdeflate-1.23-darwin.20-arm64.tar.xz -C /
+        sudo tar xJf libdeflate-1.23-darwin.20-arm64.tar.xz -C /
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -122,8 +122,15 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       shell: bash
       run: |
-        curl -LO https://mac.r-project.org/bin/darwin20/arm64/libdeflate-1.23-darwin.20-arm64.tar.xz
-        sudo tar xJf libdeflate-1.23-darwin.20-arm64.tar.xz -C /
+        LIB_ARCHIVES=(\
+          libdeflate-1.23-darwin.20-arm64.tar.xz \
+          zstd-1.5.5-darwin.20-arm64.tar.xz \
+        )
+        for name in "${LIB_ARCHIVES[@]}"
+        do
+            curl -LO https://mac.r-project.org/bin/darwin20/arm64/"${name}"
+            sudo tar xJf "${name}" -C /
+        done
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/sphinx-doc.yml
+++ b/.github/workflows/sphinx-doc.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         r-version: ${{ env.R-VERSION }}
     - name: Cache R packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: cache-R-packages
       with:

--- a/rpy2-rinterface/setup.py
+++ b/rpy2-rinterface/setup.py
@@ -80,9 +80,6 @@ class COMPILATION_STATUS(enum.Enum):
 
 def get_c_extension_status(libraries=['R'], include_dirs=None,
                            library_dirs=None):
-    # Assume OK to debug CI pipeline on macos.
-    if True:
-        return COMPILATION_STATUS.OK
     if os.name == 'nt':
         c_code = ('int main(int argc, char **argv) { return 0; }')
     else:

--- a/rpy2-rinterface/setup.py
+++ b/rpy2-rinterface/setup.py
@@ -80,6 +80,9 @@ class COMPILATION_STATUS(enum.Enum):
 
 def get_c_extension_status(libraries=['R'], include_dirs=None,
                            library_dirs=None):
+    # Assume OK to debug CI pipeline on macos.
+    if True:
+        return COMPILATION_STATUS.OK
     if os.name == 'nt':
         c_code = ('int main(int argc, char **argv) { return 0; }')
     else:

--- a/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
@@ -49,7 +49,7 @@ def test_set_consolewrite_print():
 @pytest.mark.xfail(
     condition=(ffi_proxy.get_ffi_mode(openrlib._rinterface_cffi)
                ==
-               openrlib.InterfaceType.ABI),
+               ffi_proxy.InterfaceType.ABI),
     reason='Exceptions from callbacks are propagated back when in ABI mode.'
 )
 def test_consolewrite_print_error(caplog):

--- a/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
@@ -8,6 +8,7 @@ import tempfile
 import sys
 import rpy2.rinterface as rinterface
 from rpy2.rinterface_lib import callbacks
+from rpy2.rinterface_lib import ffi_proxy
 from rpy2.rinterface_lib import openrlib
 
 rinterface.initr()
@@ -45,6 +46,12 @@ def test_set_consolewrite_print():
         assert '[1] "3"\n' == ''.join(buf)
 
 
+@pytest.mark.xfail(
+    condition=(ffi_proxy.get_ffi_mode(openrlib._rinterface_cffi)
+               ==
+               openrlib.InterfaceType.ABI),
+    reason='Exceptions from callbacks are propagated back when in ABI mode.'
+)
 def test_consolewrite_print_error(caplog):
 
     msg = "Doesn't work."

--- a/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
@@ -50,7 +50,7 @@ def test_consolewrite_print_error(caplog):
     msg = "Doesn't work."
 
     def f(x):
-        raise Exception(msg)
+        raise RuntimeError(msg)
 
     with utils.obj_in_module(callbacks, 'consolewrite_print', f),\
             caplog.at_level(logging.ERROR, logger='callbacks.logger'):
@@ -59,10 +59,17 @@ def test_consolewrite_print_error(caplog):
         rinterface.baseenv["print"](code)
         assert len(caplog.record_tuples) > 0
         for x in caplog.record_tuples:
-            assert x == ('rpy2.rinterface_lib.callbacks',
-                         logging.ERROR,
-                         (callbacks
-                          ._WRITECONSOLE_EXCEPTION_LOG % msg))
+            assert x[0] == 'rpy2.rinterface_lib.callbacks'
+            assert x[1] == logging.ERROR
+            assert x[2].startswith(
+                callbacks
+                ._WRITECONSOLE_EXCEPTION_LOG
+                .format(
+                    exception=RuntimeError,
+                    exc_value=msg,
+                    traceback=''
+                )
+            )
 
 
 def testSetResetConsole():
@@ -174,7 +181,7 @@ def test_console_read_with_error(caplog):
     msg = "Doesn't work."
 
     def f(prompt):
-        raise Exception(msg)
+        raise RuntimeError(msg)
 
     with utils.obj_in_module(callbacks, 'consoleread', f),\
             caplog.at_level(logging.ERROR, logger='callbacks.logger'):
@@ -182,14 +189,8 @@ def test_console_read_with_error(caplog):
         prompt = openrlib.ffi.new('char []', b'foo')
         n = 1000
         buf = openrlib.ffi.new('char [%i]' % n)
-        res = callbacks._consoleread(prompt, buf, n, 0)
-        assert res == 0
-        assert len(caplog.record_tuples) > 0
-        for x in caplog.record_tuples:
-            assert x == ('rpy2.rinterface_lib.callbacks',
-                         logging.ERROR,
-                         (callbacks
-                          ._READCONSOLE_EXCEPTION_LOG % msg))
+        with pytest.raises(RuntimeError):
+            res = callbacks._consoleread(prompt, buf, n, 0)
 
 
 def test_showmessage_default(capsys):

--- a/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface/tests/test_callbacks.py
@@ -217,7 +217,10 @@ def test_console_read_with_error_abi(caplog):
             caplog.at_level(logging.ERROR, logger='callbacks.logger'):
         code = rinterface.StrSexpVector(["3", ])
         caplog.clear()
-        rinterface.baseenv["print"](code)
+        prompt = openrlib.ffi.new('char []', b'foo')
+        n = 1000
+        buf = openrlib.ffi.new('char [%i]' % n)
+        res = callbacks._consoleread(prompt, buf, n, 0)
         assert len(caplog.record_tuples) > 0
         for x in caplog.record_tuples:
             assert x[0] == 'rpy2.rinterface_lib.callbacks'
@@ -231,6 +234,7 @@ def test_console_read_with_error_abi(caplog):
                     traceback=''
                 )
             )
+        assert res == 0
 
 
 def test_showmessage_default(capsys):

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/_rinterface_cffi_build.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/_rinterface_cffi_build.py
@@ -253,6 +253,7 @@ def createbuilder_api():
                 ffi_proxy._cleanup_def,
                 ffi_proxy._showfiles_def,
                 ffi_proxy._processevents_def,
+                # ffi_proxy._polled_events_def,
                 ffi_proxy._busy_def,
                 ffi_proxy._callback_def,
                 ffi_proxy._yesnocancel_def,

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
@@ -28,7 +28,6 @@ _POLLEDEVENTS_EXCEPTION_LOG = (
 )
 
 
-
 # TODO: rename to "replace_in_module"
 @contextmanager
 def obj_in_module(module, name: str, obj: typing.Any):

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
@@ -390,15 +390,3 @@ def _yesnocancel(question):
     except Exception as e:
         logger.error(_YESNOCANCEL_EXCEPTION_LOG, str(e))
     return res
-
-
-# def polled_events():
-#     pass
-
-# TODO: complete callback for polled events.
-# @ffi_proxy.callback(ffi_proxy._polled_events_def,
-#                     openrlib._rinterface_cffi,
-#                     error=None,
-#                     onerror=handler_callback_error(_POLLEDEVENTS_EXCEPTION_LOG))
-# def _polled_events():
-#     polled_events()

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
@@ -17,6 +17,16 @@ from rpy2.rinterface_lib import conversion
 logger = logging.getLogger(__name__)
 
 _CCHAR_ENCODING = sys.getdefaultencoding()
+_READCONSOLE_EXCEPTION_LOG = (
+    'R callback read-console: {exception} {exc_value} {traceback}'
+)
+_WRITECONSOLE_EXCEPTION_LOG = (
+    'R callback write-console: {exception} {exc_value} {traceback}'
+)
+_POLLEDEVENTS_EXCEPTION_LOG = (
+    'R callback polled-events: {exception} {exc_value} {traceback}'
+)
+
 
 
 # TODO: rename to "replace_in_module"
@@ -42,6 +52,18 @@ def replace_in_module(module, name: str, obj: typing.Any):
         yield
     finally:
         setattr(module, name, obj_orig)
+
+
+def handler_callback_error(log_template):
+    def func(exception, exc_value, traceback):
+        logger.error(
+            log_template.format(
+                exception=exception,
+                exc_value=exc_value,
+                traceback=traceback
+            )
+        )
+    return func
 
 
 def consoleflush():
@@ -70,45 +92,31 @@ def consoleread(prompt: str) -> str:
     return input(prompt)
 
 
-_READCONSOLE_EXCEPTION_LOG = 'R[read into console]: %s'
-_READCONSOLE_INTERNAL_EXCEPTION_LOG = ('Internal rpy2 error with '
-                                       '_consoleread callback: %s')
-
-
 @ffi_proxy.callback(ffi_proxy._consoleread_def,
-                    openrlib._rinterface_cffi)
+                    openrlib._rinterface_cffi,
+                    error=0,
+                    onerror=handler_callback_error(_READCONSOLE_EXCEPTION_LOG))
 def _consoleread(prompt, buf, n: int, addtohistory) -> int:
     success = None
-    try:
-        s = conversion._cchar_to_str(prompt, _CCHAR_ENCODING)
-        with openrlib.rlock:
-            reply = consoleread(s)
-    except Exception as e:
-        success = 0
-        logger.error(_READCONSOLE_EXCEPTION_LOG, str(e))
-    if success == 0:
-        return success
+    s = conversion._cchar_to_str(prompt, _CCHAR_ENCODING)
+    with openrlib.rlock:
+        reply = consoleread(s)
 
-    try:
-        # TODO: Should the coding be dynamically extracted from
-        # elsewhere ?
-        reply_b = reply.encode('utf-8')
-        reply_n = min(n, len(reply_b))
-        pybuf = bytearray(n)
-        pybuf[:reply_n] = reply_b[:reply_n]
-        pybuf[reply_n] = ord('\n')
-        pybuf[reply_n+1] = 0
-        openrlib.ffi.memmove(buf,
-                             pybuf,
-                             n)
-        if reply_n == 0:
-            success = 0
-        else:
-            success = 1
-    except Exception as e:
+    # TODO: Should the coding be dynamically extracted from
+    # elsewhere ?
+    reply_b = reply.encode('utf-8')
+    reply_n = min(n, len(reply_b))
+    pybuf = bytearray(n)
+    pybuf[:reply_n] = reply_b[:reply_n]
+    pybuf[reply_n] = ord('\n')
+    pybuf[reply_n+1] = 0
+    openrlib.ffi.memmove(buf,
+                         pybuf,
+                         n)
+    if reply_n == 0:
         success = 0
-        logger.error(_READCONSOLE_INTERNAL_EXCEPTION_LOG,
-                     str(e))
+    else:
+        success = 1
     return success
 
 
@@ -140,24 +148,26 @@ def consolewrite_print(s: str) -> None:
 
 def consolewrite_warnerror(s: str) -> None:
     # TODO: use an rpy2/R-specific warning instead of UserWarning.
-    logger.warning(_WRITECONSOLE_EXCEPTION_LOG, s)
-
-
-_WRITECONSOLE_EXCEPTION_LOG = 'R[write to console]: %s'
+    logger.warning(
+        _WRITECONSOLE_EXCEPTION_LOG.format(
+            exception=s,
+            exc_value='',
+            traceback=''
+        )
+    )
 
 
 @ffi_proxy.callback(ffi_proxy._consolewrite_ex_def,
-                    openrlib._rinterface_cffi)
+                    openrlib._rinterface_cffi,
+                    error=None,
+                    onerror=handler_callback_error(_WRITECONSOLE_EXCEPTION_LOG))
 def _consolewrite_ex(buf, n: int, otype: int) -> None:
     s = conversion._cchar_to_str_with_maxlen(buf, n, _CCHAR_ENCODING)
-    try:
-        with openrlib.rlock:
-            if otype == 0:
-                consolewrite_print(s)
-            else:
-                consolewrite_warnerror(s)
-    except Exception as e:
-        logger.error(_WRITECONSOLE_EXCEPTION_LOG, str(e))
+    with openrlib.rlock:
+        if otype == 0:
+            consolewrite_print(s)
+        else:
+            consolewrite_warnerror(s)
 
 
 def showmessage(s: str) -> None:
@@ -381,3 +391,15 @@ def _yesnocancel(question):
     except Exception as e:
         logger.error(_YESNOCANCEL_EXCEPTION_LOG, str(e))
     return res
+
+
+# def polled_events():
+#     pass
+
+# TODO: complete callback for polled events.
+# @ffi_proxy.callback(ffi_proxy._polled_events_def,
+#                     openrlib._rinterface_cffi,
+#                     error=None,
+#                     onerror=handler_callback_error(_POLLEDEVENTS_EXCEPTION_LOG))
+# def _polled_events():
+#     polled_events()

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
@@ -236,7 +236,6 @@ CALLBACK_INIT_PAIRS = (
     ('ptr_R_CleanUp', '_cleanup'),
     ('ptr_R_ProcessEvents', '_processevents'),
     ('ptr_R_Busy', '_busy'),
-    # ('R_PolledEvents', None)
 )
 
 # TODO: can init_once() be used here ?

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
@@ -209,7 +209,14 @@ class RRuntimeError(Exception):
 def _setcallback(rlib, rlib_symbol: str,
                  callbacks,
                  callback_symbol: typing.Optional[str]) -> None:
-    """Set R callbacks."""
+    """Set R callbacks.
+
+    :param rlib: Namespace
+    :param rlib_symbol: Symbol (name) in the namespace in which to place
+      the new callback function
+    :param callbacks: Namespace in which to find the callback function.
+    :param callbacks_symbol: Symbol (name) of the new callback function.
+"""
     if callback_symbol is None:
         new_callback = ffi.NULL
     else:

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
@@ -217,18 +217,20 @@ def _setcallback(rlib, rlib_symbol: str,
     setattr(rlib, rlib_symbol, new_callback)
 
 
-CALLBACK_INIT_PAIRS = (('ptr_R_WriteConsoleEx', '_consolewrite_ex'),
-                       ('ptr_R_WriteConsole', None),
-                       ('ptr_R_ShowMessage', '_showmessage'),
-                       ('ptr_R_ReadConsole', '_consoleread'),
-                       ('ptr_R_FlushConsole', '_consoleflush'),
-                       ('ptr_R_ResetConsole', '_consolereset'),
-                       ('ptr_R_ChooseFile', '_choosefile'),
-                       ('ptr_R_ShowFiles', '_showfiles'),
-                       ('ptr_R_CleanUp', '_cleanup'),
-                       ('ptr_R_ProcessEvents', '_processevents'),
-                       ('ptr_R_Busy', '_busy'))
-
+CALLBACK_INIT_PAIRS = (
+    ('ptr_R_WriteConsoleEx', '_consolewrite_ex'),
+    ('ptr_R_WriteConsole', None),
+    ('ptr_R_ShowMessage', '_showmessage'),
+    ('ptr_R_ReadConsole', '_consoleread'),
+    ('ptr_R_FlushConsole', '_consoleflush'),
+    ('ptr_R_ResetConsole', '_consolereset'),
+    ('ptr_R_ChooseFile', '_choosefile'),
+    ('ptr_R_ShowFiles', '_showfiles'),
+    ('ptr_R_CleanUp', '_cleanup'),
+    ('ptr_R_ProcessEvents', '_processevents'),
+    ('ptr_R_Busy', '_busy'),
+    # ('R_PolledEvents', None)
+)
 
 # TODO: can init_once() be used here ?
 if os.name == 'nt':

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded_mswin.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded_mswin.py
@@ -18,6 +18,7 @@ _DEFAULT_R_INTERACTIVE: bool = True
 
 def _build_rstart(rhome, interactive, setcallbacks):
     rstart = ffi.new('Rstart')
+    openrlib.rlib.R_DefParams(rstart)
     rstart.rhome = rhome
     rstart.home = openrlib.rlib.getRUser()
     rstart.CharacterMode = openrlib.rlib.LinkDLL

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded_mswin.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded_mswin.py
@@ -16,6 +16,32 @@ _DEFAULT_C_STACK_LIMIT: int = -1
 _DEFAULT_R_INTERACTIVE: bool = True
 
 
+def _build_rstart(rhome, interactive, setcallbacks):
+    rstart = ffi.new('Rstart')
+    rstart.rhome = rhome
+    rstart.home = openrlib.rlib.getRUser()
+    rstart.CharacterMode = openrlib.rlib.LinkDLL
+    if setcallbacks:
+        rstart.ReadConsole = callbacks._consoleread
+        rstart.WriteConsoleEx = callbacks._consolewrite_ex
+        rstart.CallBack = callbacks._callback
+        rstart.ShowMessage = callbacks._showmessage
+        rstart.YesNoCancel = callbacks._yesnocancel
+        rstart.Busy = callbacks._busy
+
+    rstart.R_Quiet = True
+    rstart.R_Interactive = interactive
+    rstart.RestoreAction = openrlib.rlib.SA_RESTORE
+    rstart.SaveAction = openrlib.rlib.SA_NOSAVE
+
+    rstart.vsize = ffi.cast('size_t', _DEFAULT_VSIZE)
+    rstart.nsize = ffi.cast('size_t', _DEFAULT_NSIZE)
+    rstart.max_vsize = ffi.cast('size_t', _DEFAULT_MAX_VSIZE)
+    rstart.max_nsize = ffi.cast('size_t', _DEFAULT_MAX_NSIZE)
+    rstart.ppsize = ffi.cast('size_t', _DEFAULT_PPSIZE)
+    return rstart
+
+
 def _initr_win32(
         interactive: typing.Optional[bool] = None,
         _want_setcallbacks: bool = True,
@@ -48,31 +74,8 @@ def _initr_win32(
         status = openrlib.rlib.Rf_initEmbeddedR(n_options_c, options_c)
         embedded._setinitialized()
 
-        embedded.rstart = ffi.new('Rstart')
-        rstart = embedded.rstart
         rhome = openrlib.rlib.get_R_HOME()
-        rstart.rhome = rhome
-        rstart.home = openrlib.rlib.getRUser()
-        rstart.CharacterMode = openrlib.rlib.LinkDLL
-        if _want_setcallbacks:
-            rstart.ReadConsole = callbacks._consoleread
-            rstart.WriteConsoleEx = callbacks._consolewrite_ex
-            rstart.CallBack = callbacks._callback
-            rstart.ShowMessage = callbacks._showmessage
-            rstart.YesNoCancel = callbacks._yesnocancel
-            rstart.Busy = callbacks._busy
-
-        rstart.R_Quiet = True
-        rstart.R_Interactive = interactive
-        rstart.RestoreAction = openrlib.rlib.SA_RESTORE
-        rstart.SaveAction = openrlib.rlib.SA_NOSAVE
-
-        rstart.vsize = ffi.cast('size_t', _DEFAULT_VSIZE)
-        rstart.nsize = ffi.cast('size_t', _DEFAULT_NSIZE)
-        rstart.max_vsize = ffi.cast('size_t', _DEFAULT_MAX_VSIZE)
-        rstart.max_nsize = ffi.cast('size_t', _DEFAULT_MAX_NSIZE)
-        rstart.ppsize = ffi.cast('size_t', _DEFAULT_PPSIZE)
-
+        embedded.rstart = _build_rstart(rhome, interactive, _want_setcallbacks)
         openrlib.rlib.R_SetParams(rstart)
 
         # TODO: still needed ?

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded_mswin.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded_mswin.py
@@ -77,7 +77,7 @@ def _initr_win32(
 
         rhome = openrlib.rlib.get_R_HOME()
         embedded.rstart = _build_rstart(rhome, interactive, _want_setcallbacks)
-        openrlib.rlib.R_SetParams(rstart)
+        openrlib.rlib.R_SetParams(embedded.rstart)
 
         # TODO: still needed ?
         openrlib.rlib.R_CStackLimit = ffi.cast('uintptr_t', _c_stack_limit)

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
@@ -62,7 +62,7 @@ def _callback_wrapper_ABI(func, onerror):
     def outer_func(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception as err:
+        except Exception:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             onerror(exc_type, exc_value, exc_traceback)
     return outer_func

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
@@ -52,7 +52,12 @@ def get_ffi_mode(_rinterface_cffi: types.ModuleType) -> InterfaceType:
     return FFI_MODE
 
 
-def _callback_wrapper_ABI(func, error, onerror):
+def _callback_wrapper_ABI(func, onerror):
+    """
+    :param:func: a callback function.
+    :param:onerror: a callback to run if there is an error.
+    :returns: a closure wrapping `func`.
+    """
     def outer_func(*args, **kwargs):
         try:
             return func(*args, **kwargs)
@@ -69,7 +74,7 @@ def callback(
     def decorator(func: typing.Callable) -> object:
         if get_ffi_mode(_rinterface_cffi) == InterfaceType.ABI:
             res = _rinterface_cffi.ffi.callback(definition.callback_def)(
-                _callback_wrapper_ABI(func)
+                _callback_wrapper_ABI(func, onerror)
             )
         elif get_ffi_mode(_rinterface_cffi) == InterfaceType.API:
             res = _rinterface_cffi.ffi.def_extern(

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
@@ -62,7 +62,7 @@ def _callback_wrapper_ABI(func, onerror):
     def outer_func(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception:
+        except Exception as err:
             exc_type, exc_value, exc_traceback = sys.exc_info()
             onerror(exc_type, exc_value, exc_traceback)
     return outer_func

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
@@ -128,10 +128,6 @@ _showfiles_def: SignatureDefinition = SignatureDefinition(
      'const char *'))
 _processevents_def: SignatureDefinition = SignatureDefinition(
     '_processevents', 'void', ('void', ))
-
-# _polled_events_def: SignatureDefinition = SignatureDefinition(
-#     '_polled_events', 'void', ('void', ))
-
 _busy_def: SignatureDefinition = SignatureDefinition(
     '_busy', 'void', ('int', ))
 _callback_def: SignatureDefinition = SignatureDefinition(

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
@@ -53,13 +53,16 @@ def get_ffi_mode(_rinterface_cffi: types.ModuleType) -> InterfaceType:
 
 
 def callback(
-        definition, _rinterface_cffi
+        definition, _rinterface_cffi,
+        error=None, onerror=None
 ) -> typing.Callable[[typing.Callable], object]:
     def decorator(func: typing.Callable) -> object:
         if get_ffi_mode(_rinterface_cffi) == InterfaceType.ABI:
             res = _rinterface_cffi.ffi.callback(definition.callback_def)(func)
         elif get_ffi_mode(_rinterface_cffi) == InterfaceType.API:
-            res = _rinterface_cffi.ffi.def_extern()(func)
+            res = _rinterface_cffi.ffi.def_extern(
+                error=error, onerror=onerror
+            )(func)
         else:
             raise RuntimeError('The cffi mode is neither ABI or API.')
         return res
@@ -107,6 +110,10 @@ _showfiles_def: SignatureDefinition = SignatureDefinition(
      'const char *'))
 _processevents_def: SignatureDefinition = SignatureDefinition(
     '_processevents', 'void', ('void', ))
+
+# _polled_events_def: SignatureDefinition = SignatureDefinition(
+#     '_polled_events', 'void', ('void', ))
+
 _busy_def: SignatureDefinition = SignatureDefinition(
     '_busy', 'void', ('int', ))
 _callback_def: SignatureDefinition = SignatureDefinition(

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/ffi_proxy.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 import os
+import sys
 import types
 import typing
 


### PR DESCRIPTION
Errors in R's C-API callbacks implemented in Python.