### PR TITLE
Add consolewrite to callback init pairs

### DIFF
--- a/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/callbacks.py
@@ -169,6 +169,16 @@ def _consolewrite_ex(buf, n: int, otype: int) -> None:
             consolewrite_warnerror(s)
 
 
+@ffi_proxy.callback(ffi_proxy._consolewrite_def,
+                    openrlib._rinterface_cffi,
+                    error=None,
+                    onerror=handler_callback_error(_WRITECONSOLE_EXCEPTION_LOG))
+def _consolewrite(buf, n: int) -> None:
+    s = conversion._cchar_to_str_with_maxlen(buf, n, encoding='utf-8')
+    with openrlib.rlock:
+        consolewrite_print(s)
+
+
 def showmessage(s: str) -> None:
     print('R wants to show a message')
     print(s)

--- a/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
+++ b/rpy2-rinterface/src/rpy2/rinterface_lib/embedded.py
@@ -270,7 +270,7 @@ _CallbackInit = collections.namedtuple(
 
 CALLBACK_INIT_PAIRS: typing.Tuple[_CallbackInit, ...] = (
     _CallbackInit('ptr_R_WriteConsoleEx', 'WriteConsoleEx', '_consolewrite_ex'),
-    _CallbackInit('ptr_R_WriteConsole', 'WriteConsole', None),
+    _CallbackInit('ptr_R_WriteConsole', 'WriteConsole', '_consolewrite'),
     _CallbackInit('ptr_R_ShowMessage', 'ShowMessage', '_showmessage'),
     _CallbackInit('ptr_R_ReadConsole', 'ReadConsole', '_consoleread'),
     _CallbackInit('ptr_R_FlushConsole', None, '_consoleflush'),


### PR DESCRIPTION
Implements `_consolewrite` based on `_consolewrite_ex`, enabling R console output via Python.

This aims to close #1183 by registering and providing an implementation for `ffi_proxy._consolewrite_def`.

The definition for `_consolewrite_def` is already present in `_rinterface_cffi_build.py`
(see lines 241–262: https://github.com/rpy2/rpy2/blob/316340b1c7f54e988f886c9212f4b939b1a6abc2/rpy2-rinterface/src/rpy2/rinterface_lib/_rinterface_cffi_build.py#L249C27-L249C44),
but previously had no corresponding callback function in Python.

```python
callback_defns_api = '\n'.join(
        x.extern_python_def
        for x in [
                ...
                ffi_proxy._consolereset_def,
                ffi_proxy._consolewrite_def,
                ffi_proxy._consolewrite_ex_def,
                ffi_proxy._showmessage_def,
                ...
        ])
```

⚠️ Disclaimer: Automated tests for this implementation have not been added yet.