### PR TITLE
Update pyproject.toml

### DIFF
--- a/rpy2-rinterface/pyproject.toml
+++ b/rpy2-rinterface/pyproject.toml
@@ -13,7 +13,7 @@ name = "rpy2-rinterface"
 description = "Low-level interface from Python to the R."
 readme = "README.md"
 requires-python = ">=3.8"
-license = "GPL-2.0-or-later"
+license = { text = "GPL-2.0-or-later" }
 authors = [{ name = "Laurent Gautier", email = "lgautier@gmail.com" }]
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
Require setuptools >= 77 to ensure license definition is recognized (issue #1198).