### PR TITLE
Declare noise when checking environment variables (issue #1201)

### DIFF
--- a/rpy2-rinterface/src/rpy2/rinterface/__init__.py
+++ b/rpy2-rinterface/src/rpy2/rinterface/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import atexit
+import collections
 import contextlib
 import contextvars
 import csv
@@ -62,6 +63,11 @@ class _ENVVAR_ACTION(enum.Enum):
 
 
 _DEFAULT_ENVVAR_ACTION: _ENVVAR_ACTION = _ENVVAR_ACTION.REPLACE_WARN
+
+_ENVAR_ACTION_MAP = collections.defaultdict(
+    lambda: _DEFAULT_ENVVAR_ACTION,
+    {'R_SESSION_TMPDIR': _ENVAR_ACTION.KEEP_NOWARN}
+)
 
 
 def get_evaluation_context() -> SexpEnvironment:
@@ -1118,7 +1124,7 @@ def initr(
             logger.info('R is already initialized. No need to initialize.')
             return None
 
-        _setrenvvars(_DEFAULT_ENVVAR_ACTION)
+        _setrenvvars(_ENVVAR_ACTION_MAP)
         if embedded.is_r_externally_initialized():
             embedded._setinitialized()
         else:
@@ -1208,10 +1214,11 @@ def _getrenvvars(
     return tuple(res)
 
 
-def _setrenvvars(action: _ENVVAR_ACTION):
+def _setrenvvars(action_map: typing.Dict[str, _ENVVAR_ACTION]):
     new_envvars = {}
     for k, v in _getrenvvars():
         if k in os.environ:
+            action = action_map[k]
             if action in (_ENVVAR_ACTION.KEEP_WARN, _ENVVAR_ACTION.KEEP_NOWARN):
                 if action is _ENVVAR_ACTION.KEEP_WARN:
                     logger.info(


### PR DESCRIPTION
- [ ] expand variables in Python (since done in the R subprocess)
- [ ] check path equivalence
- [ X] make R_SESSION_TMPDIR silenty conserved.