### PR TITLE
Update SQLite connection method in dplyr example

### DIFF
--- a/doc/notebooks/dplyr.md
+++ b/doc/notebooks/dplyr.md
@@ -169,7 +169,7 @@ res = (
 print(res)
 
 # Close the connection to clean up.
-DBI.dbDisconnect(dbcon)
+dbi.dbDisconnect(dbcon)
 ```
 
 Since we are manipulating R objects, anything available to R is also available


### PR DESCRIPTION
Updated the example code to use DBI and RSQLite for SQLite database connection instead of the function `src_sqlite` that is no longer supported by `dplyr.