### PR TITLE
fix: remove invalid super().__del__() call in Package

### DIFF
--- a/rpy2-robjects/src/rpy2/robjects/help.py
+++ b/rpy2-robjects/src/rpy2/robjects/help.py
@@ -343,7 +343,6 @@ class Package(object):
 
     def __del__(self):
         self._dbcon.close()
-        super().__del__()
 
     def fetch(self, alias: str) -> Page:
         """ Fetch the documentation page associated with a given alias.


### PR DESCRIPTION
## Bug
https://github.com/rpy2/rpy2/issues/1233 — Deleting a `robjects.help.Package` instance raises `AttributeError: 'super' object has no attribute '__del__'`.

## Fix
`Package` inherits from `object`, which does not define `__del__`. The call to `super().__del__()` in `Package.__del__` is therefore invalid and raises an `AttributeError` during garbage collection. This PR simply removes that spurious call; the database connection close (`self._dbcon.close()`) is unaffected.

## Testing
Verified that `object` has no `__del__` attribute (`hasattr(object, '__del__')` returns `False`). After the fix, `del Package('graphics')` completes without error.

Happy to address any feedback.

Greetings, saschabuehrle